### PR TITLE
[#12] 4.04 오늘의 상/하위 종목 API 구현

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { TopfiveModule } from './stocks/topfive/topfive.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { AppService } from './app.service';
       entities: [],
       synchronize: true,
     }),
+    TopfiveModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BE/src/stocks/topfive/dto/stock-ranking-data.dto.ts
+++ b/BE/src/stocks/topfive/dto/stock-ranking-data.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 등락률 API 요청 후 받은 응답값 정제용 DTO
+ */
+export class StockRankingDataDto {
+  @ApiProperty({ description: 'HTS 한글 종목명' })
+  hts_kor_isnm: string;
+
+  @ApiProperty({ description: '주식 현재가' })
+  stck_prpr: string;
+
+  @ApiProperty({ description: '전일 대비' })
+  prdy_vrss: string;
+
+  @ApiProperty({ description: '전일 대비 부호' })
+  prdy_vrss_sign: string;
+
+  @ApiProperty({ description: '전일 대비율' })
+  prdy_ctrt: string;
+}

--- a/BE/src/stocks/topfive/dto/stock-ranking-request.dto.ts
+++ b/BE/src/stocks/topfive/dto/stock-ranking-request.dto.ts
@@ -1,0 +1,23 @@
+/**
+ * 등락률 API를 사용할 때 쿼리 파라미터로 사용할 요청값 DTO
+ */
+export class StockRankigRequestDto {
+  /**
+   * 조건 시장 분류 코드
+   * 'J' 주식
+   */
+  fid_cond_mrkt_div_code: string;
+
+  /**
+   * 입력 종목 코드
+   * '0000' 전체 / '0001' 코스피
+   * '1001' 코스닥 / '2001' 코스피200
+   */
+  fid_input_iscd: string;
+
+  /**
+   * 순위 정렬 구분 코드
+   * '0' 상승률 / '1' 하락률
+   */
+  fid_rank_sort_cls_code: string;
+}

--- a/BE/src/stocks/topfive/dto/stock-ranking-response.dto.ts
+++ b/BE/src/stocks/topfive/dto/stock-ranking-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { StockRankingDataDto } from './stock-ranking-data.dto';
+
+/**
+ * 순위 정렬 후 FE에 보낼 DTO
+ */
+export class StockRankingResponseDto {
+  @ApiProperty({ type: [StockRankingDataDto], description: '상승률 순위' })
+  high: StockRankingDataDto[];
+
+  @ApiProperty({ type: [StockRankingDataDto], description: '하락률 순위' })
+  low: StockRankingDataDto[];
+}

--- a/BE/src/stocks/topfive/topfive.controller.ts
+++ b/BE/src/stocks/topfive/topfive.controller.ts
@@ -1,0 +1,28 @@
+import { ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { Controller, Get, Query } from '@nestjs/common';
+import { TopFiveService, MarketType } from './topfive.service';
+import { StockRankingResponseDto } from './dto/stock-ranking-response.dto';
+
+@Controller('/api/stocks')
+export class TopfiveController {
+  constructor(private readonly topFiveService: TopFiveService) {}
+
+  @Get('topfive')
+  @ApiOperation({ summary: '오늘의 상/하위 종목 조회 API' })
+  @ApiQuery({
+    name: 'market',
+    enum: MarketType,
+    required: true,
+    description:
+      '주식 시장 구분\n' +
+      'ALL: 전체, KOSPI: 코스피, KOSDAQ: 코스닥, KOSPI200: 코스피200',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '주식 시장별 순위 조회 성공',
+    type: StockRankingResponseDto,
+  })
+  async getTopFive(@Query('market') market: MarketType) {
+    return this.topFiveService.getMarketRanking(market);
+  }
+}

--- a/BE/src/stocks/topfive/topfive.module.ts
+++ b/BE/src/stocks/topfive/topfive.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TopfiveController } from './topfive.controller';
+import { TopFiveService } from './topfive.service';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [TopfiveController],
+  providers: [TopFiveService],
+})
+export class TopfiveModule {}

--- a/BE/src/stocks/topfive/topfive.service.ts
+++ b/BE/src/stocks/topfive/topfive.service.ts
@@ -1,6 +1,50 @@
 import axios from 'axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { StockRankigRequestDto } from './dto/stock-ranking-request.dto';
+import { StockRankingResponseDto } from './dto/stock-ranking-response.dto';
+import { StockRankingDataDto } from './dto/stock-ranking-data.dto';
+
+export enum MarketType {
+  ALL = 'ALL',
+  KOSPI = 'KOSPI',
+  KOSDAQ = 'KOSDAQ',
+  KOSPI200 = 'KOSPI200',
+}
+
+interface StockApiOutputData {
+  stck_shrn_iscd: string;
+  data_rank: string;
+  hts_kor_isnm: string;
+  stck_prpr: string;
+  prdy_vrss: string;
+  prdy_vrss_sign: string;
+  prdy_ctrt: string;
+  acml_vol: string;
+  stck_hgpr: string;
+  hgpr_hour: string;
+  acml_hgpr_data: string;
+  stck_lwpr: string;
+  lwpr_hour: string;
+  acml_lwpr_date: string;
+  lwpr_vrss_prpr_rate: string;
+  dsgt_date_clpr_vrss_prpr_rate: string;
+  cnnt_ascn_dynu: string;
+  hgpr_vrss_prpr_rate: string;
+  cnnt_down_dynu: string;
+  oprc_vrss_prpr_sign: string;
+  oprc_vrss_prpr: string;
+  oprc_vrss_prpr_rate: string;
+  prd_rsfl: string;
+  prd_rsfl_rate: string;
+}
+
+interface StockApiResponse {
+  output: StockApiOutputData[];
+  rt_cd: string;
+  msg_cd: string;
+  msg1: string;
+}
 
 @Injectable()
 export class TopFiveService {
@@ -39,5 +83,113 @@ export class TopFiveService {
     this.tokenExpireTime = new Date(Date.now() + +response.data.expires_in);
 
     return this.accessToken;
+  }
+
+  private async requestApi(params: StockRankigRequestDto) {
+    try {
+      const token = await this.getAccessToken();
+
+      const response = await axios.get<StockApiResponse>(
+        `${this.koreaInvestmentConfig.baseUrl}/uapi/domestic-stock/v1/ranking/fluctuation`,
+        {
+          headers: {
+            'content-type': 'application/json; charset=utf-8',
+            authorization: `Bearer ${token}`,
+            appkey: this.koreaInvestmentConfig.appKey,
+            appsecret: this.koreaInvestmentConfig.appSecret,
+            tr_id: 'FHPST01700000',
+            custtype: 'P',
+          },
+          params: {
+            fid_rsfl_rate2: '',
+            fid_cond_mrkt_div_code: params.fid_cond_mrkt_div_code,
+            fid_cond_scr_div_code: '20170',
+            fid_input_iscd: params.fid_input_iscd,
+            fid_rank_sort_cls_code: params.fid_rank_sort_cls_code,
+            fid_input_cnt_1: '0',
+            fid_prc_cls_code: '1',
+            fid_input_price_1: '',
+            fid_input_price_2: '',
+            fid_vol_cnt: '',
+            fid_trgt_cls_code: '0',
+            fid_trgt_exls_cls_code: '0',
+            fid_div_cls_code: '0',
+            fid_rsfl_rate1: '',
+          },
+        },
+      );
+      return response.data;
+    } catch (error) {
+      console.error('API Error Details:', {
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+        headers: error.response?.config?.headers, // 실제 요청 헤더
+        message: error.message,
+      });
+      throw error;
+    }
+  }
+
+  async getMarketRanking(marketType: MarketType) {
+    try {
+      const params = new StockRankigRequestDto();
+      params.fid_cond_mrkt_div_code = 'J';
+
+      switch (marketType) {
+        case MarketType.ALL:
+          params.fid_input_iscd = '0000';
+          break;
+        case MarketType.KOSPI:
+          params.fid_input_iscd = '0001';
+          break;
+        case MarketType.KOSDAQ:
+          params.fid_input_iscd = '1001';
+          break;
+        case MarketType.KOSPI200:
+          params.fid_input_iscd = '2001';
+          break;
+        default:
+          break;
+      }
+
+      const highResponse = await this.requestApi({
+        ...params,
+        fid_rank_sort_cls_code: '0',
+      });
+
+      const lowResponse = await this.requestApi({
+        ...params,
+        fid_rank_sort_cls_code: '1',
+      });
+
+      const response = new StockRankingResponseDto();
+      response.high = this.formatStockData(highResponse.output);
+      response.low = this.formatStockData(lowResponse.output);
+
+      return response;
+    } catch (error) {
+      console.error('API Error Details:', {
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+        headers: error.response?.config?.headers, // 실제 요청 헤더
+        message: error.message,
+      });
+      throw error;
+    }
+  }
+
+  private formatStockData(stocks: StockApiOutputData[]) {
+    return stocks.map((stock) => {
+      const stockData = new StockRankingDataDto();
+      stockData.hts_kor_isnm = stock.hts_kor_isnm;
+      stockData.stck_prpr = stock.stck_prpr;
+      stockData.prdy_vrss = stock.prdy_vrss;
+      stockData.prdy_vrss_sign = stock.prdy_vrss_sign;
+      stockData.prdy_ctrt = stock.prdy_ctrt;
+
+      return stockData;
+    });
   }
 }

--- a/BE/src/stocks/topfive/topfive.service.ts
+++ b/BE/src/stocks/topfive/topfive.service.ts
@@ -181,7 +181,7 @@ export class TopFiveService {
   }
 
   private formatStockData(stocks: StockApiOutputData[]) {
-    return stocks.map((stock) => {
+    return stocks.slice(0, 5).map((stock) => {
       const stockData = new StockRankingDataDto();
       stockData.hts_kor_isnm = stock.hts_kor_isnm;
       stockData.stck_prpr = stock.stck_prpr;

--- a/BE/src/stocks/topfive/topfive.service.ts
+++ b/BE/src/stocks/topfive/topfive.service.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { StockRankigRequestDto } from './dto/stock-ranking-request.dto';
 import { StockRankingResponseDto } from './dto/stock-ranking-response.dto';
@@ -56,6 +56,8 @@ export class TopFiveService {
     baseUrl: string;
   };
 
+  private readonly logger = new Logger();
+
   constructor(private readonly config: ConfigService) {
     this.koreaInvestmentConfig = {
       appKey: this.config.get<string>('KOREA_INVESTMENT_APP_KEY'),
@@ -86,7 +88,6 @@ export class TopFiveService {
   }
 
   private async requestApi(params: StockRankigRequestDto) {
-    // eslint-disable-next-line no-useless-catch
     try {
       const token = await this.getAccessToken();
 
@@ -121,19 +122,18 @@ export class TopFiveService {
       );
       return response.data;
     } catch (error) {
-      // console.error('API Error Details:', {
-      //   status: error.response?.status,
-      //   statusText: error.response?.statusText,
-      //   data: error.response?.data,
-      //   headers: error.response?.config?.headers, // 실제 요청 헤더
-      //   message: error.message,
-      // });
+      this.logger.error('API Error Details:', {
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+        headers: error.response?.config?.headers,
+        message: error.message,
+      });
       throw error;
     }
   }
 
   async getMarketRanking(marketType: MarketType) {
-    // eslint-disable-next-line no-useless-catch
     try {
       const params = new StockRankigRequestDto();
       params.fid_cond_mrkt_div_code = 'J';
@@ -171,13 +171,13 @@ export class TopFiveService {
 
       return response;
     } catch (error) {
-      // console.error('API Error Details:', {
-      //   status: error.response?.status,
-      //   statusText: error.response?.statusText,
-      //   data: error.response?.data,
-      //   headers: error.response?.config?.headers, // 실제 요청 헤더
-      //   message: error.message,
-      // });
+      this.logger.error('API Error Details:', {
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+        headers: error.response?.config?.headers, // 실제 요청 헤더
+        message: error.message,
+      });
       throw error;
     }
   }

--- a/BE/src/stocks/topfive/topfive.service.ts
+++ b/BE/src/stocks/topfive/topfive.service.ts
@@ -86,6 +86,7 @@ export class TopFiveService {
   }
 
   private async requestApi(params: StockRankigRequestDto) {
+    // eslint-disable-next-line no-useless-catch
     try {
       const token = await this.getAccessToken();
 
@@ -120,18 +121,19 @@ export class TopFiveService {
       );
       return response.data;
     } catch (error) {
-      console.error('API Error Details:', {
-        status: error.response?.status,
-        statusText: error.response?.statusText,
-        data: error.response?.data,
-        headers: error.response?.config?.headers, // 실제 요청 헤더
-        message: error.message,
-      });
+      // console.error('API Error Details:', {
+      //   status: error.response?.status,
+      //   statusText: error.response?.statusText,
+      //   data: error.response?.data,
+      //   headers: error.response?.config?.headers, // 실제 요청 헤더
+      //   message: error.message,
+      // });
       throw error;
     }
   }
 
   async getMarketRanking(marketType: MarketType) {
+    // eslint-disable-next-line no-useless-catch
     try {
       const params = new StockRankigRequestDto();
       params.fid_cond_mrkt_div_code = 'J';
@@ -169,13 +171,13 @@ export class TopFiveService {
 
       return response;
     } catch (error) {
-      console.error('API Error Details:', {
-        status: error.response?.status,
-        statusText: error.response?.statusText,
-        data: error.response?.data,
-        headers: error.response?.config?.headers, // 실제 요청 헤더
-        message: error.message,
-      });
+      // console.error('API Error Details:', {
+      //   status: error.response?.status,
+      //   statusText: error.response?.statusText,
+      //   data: error.response?.data,
+      //   headers: error.response?.config?.headers, // 실제 요청 헤더
+      //   message: error.message,
+      // });
       throw error;
     }
   }

--- a/BE/src/stocks/topfive/topfive.service.ts
+++ b/BE/src/stocks/topfive/topfive.service.ts
@@ -1,0 +1,43 @@
+import axios from 'axios';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class TopFiveService {
+  private accessToken: string;
+  private tokenExpireTime: Date;
+  private readonly koreaInvestmentConfig: {
+    appKey: string;
+    appSecret: string;
+    baseUrl: string;
+  };
+
+  constructor(private readonly config: ConfigService) {
+    this.koreaInvestmentConfig = {
+      appKey: this.config.get<string>('KOREA_INVESTMENT_APP_KEY'),
+      appSecret: this.config.get<string>('KOREA_INVESTMENT_APP_SECRET'),
+      baseUrl: this.config.get<string>('KOREA_INVESTMENT_BASE_URL'),
+    };
+  }
+
+  private async getAccessToken() {
+    // accessToken이 유효한 경우
+    if (this.accessToken && this.tokenExpireTime > new Date()) {
+      return this.accessToken;
+    }
+
+    const response = await axios.post(
+      `${this.koreaInvestmentConfig.baseUrl}/oauth2/tokenP`,
+      {
+        grant_type: 'client_credentials',
+        appkey: this.koreaInvestmentConfig.appKey,
+        appsecret: this.koreaInvestmentConfig.appSecret,
+      },
+    );
+
+    this.accessToken = response.data.access_token;
+    this.tokenExpireTime = new Date(Date.now() + +response.data.expires_in);
+
+    return this.accessToken;
+  }
+}


### PR DESCRIPTION
### ✅ 주요 작업
- [x] 한국투자 API 사용에 필요한 access token 발급 로직 구현
- [x] 상/하위 종목 조회 API에 사용할 DTO 구현
- [x] 한국투자 API 요청 및 결과값을 받아오는 로직 구현
  - [x] 순위 5개까지만 받아올 수 있도록 구현
- [x] Controller 구현
- [x] app module에 추가


### 💭 고민과 해결과정
- access token이 필요한 API를 호출할 때마다 서비스 로직에서 access token을 요청하는 상황은 이상하다고 생각한다. 내일 BE 개발 담당자분들과 이야기를 통해 수정이 필요할 것 같다.
- API 문서를 제대로 읽지 않고 쿼리 파라미터에서 필요하다고 판단한 내용만 전달했다가 결과값이 비어있는 채로 넘어와서 문제가 생겼다. API 문서를 다시 읽고 누락된 쿼리 파라미터 값을 추가해 해결할 수 있었다.
- **`.env`** 파일에서 환경변수를 제대로 가지고 오지 못하는 문제가 발생했다. **`@nestjs/config`** 의 **`ConfigService`** 를 이용해 가지고 오는 방식으로 변경해 해결할 수 있었다.
