### PR TITLE
[FE] websocket 연결 단 한 번만 하도록 수정 #10

### DIFF
--- a/FE/src/components/StockIndex/Card.tsx
+++ b/FE/src/components/StockIndex/Card.tsx
@@ -4,7 +4,7 @@ import {
   StockIndexValue,
 } from 'components/TopFive/type';
 import { useEffect, useRef, useState } from 'react';
-import { io } from 'socket.io-client';
+import { socket } from 'socket';
 import { drawChart } from 'utils/chart';
 
 // const X_LENGTH = 79;
@@ -25,8 +25,6 @@ export function Card({ name, id, initialData }: StockIndexChartProps) {
 
   const changeColor =
     Number(value.diff) > 0 ? 'text-juga-red-60' : 'text-juga-blue-50';
-
-  const socket = io('http://223.130.151.42:3000/socket');
 
   socket.on(id, (stockIndex) => {
     setStockIndexValue(stockIndex);

--- a/FE/src/socket.ts
+++ b/FE/src/socket.ts
@@ -1,0 +1,3 @@
+import { io } from 'socket.io-client';
+
+export const socket = io('http://223.130.151.42:3000/socket');


### PR DESCRIPTION
### ✅ 주요 작업
- websocket 연결 에러 해결

### 💭 고민과 해결과정
컴포넌트가 렌더링될 때마다 socket을 연결했었다.
컴포넌트가 리렌더링될때마다 socket을 계속 연결해주니 에러가 발생했다.
socket을 전역으로 한 번만 연결해줘서 해결할 수 있었다.
