### PR TITLE
[FE] 검색 리스트 컴포넌트 구현.

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -9,6 +9,7 @@ import Home from 'page/Home';
 import StocksDetail from 'page/StocksDetail';
 import Header from 'components/Header';
 import Login from 'components/Login';
+import SearchModal from './components/Search';
 
 function App() {
   return (
@@ -33,6 +34,7 @@ function Layout() {
         <Outlet />
       </main>
       <Login />
+      <SearchModal />
     </>
   );
 }

--- a/FE/src/components/Header.tsx
+++ b/FE/src/components/Header.tsx
@@ -2,11 +2,13 @@ import { Link } from 'react-router-dom';
 import useAuthStore from 'store/authStore';
 import useLoginModalStore from 'store/useLoginModalStore';
 import useSearchModalStore from '../store/useSearchModalStore.ts';
+import useSearchInputStore from '../store/useSearchInputStore.ts';
 
 export default function Header() {
   const { toggleModal } = useLoginModalStore();
   const { isLogin, resetToken } = useAuthStore();
   const { toggleSearchModal } = useSearchModalStore();
+  const { searchInput } = useSearchInputStore();
 
   return (
     <header className='fixed left-0 top-0 h-[60px] w-full'>
@@ -26,6 +28,7 @@ export default function Header() {
             <input
               type='text'
               placeholder='Search...'
+              value={searchInput}
               className='h-[36px] w-[280px] rounded-lg bg-juga-grayscale-50 px-4 py-2'
               onClick={toggleSearchModal}
             />

--- a/FE/src/components/Search/SearchCard.tsx
+++ b/FE/src/components/Search/SearchCard.tsx
@@ -1,26 +1,7 @@
-type SearchCardProps = {
-  companyName: string;
-  previousClose: number;
-  priceChange: number;
-};
-
-export default function SearchCard({
-  companyName = '회사명',
-  previousClose = 50000,
-  priceChange = 2.5,
-}: SearchCardProps) {
-  const isPositive = priceChange > 0;
-  const isNegative = priceChange < 0;
-
-  const getPriceChangeColor = () => {
-    if (isPositive) return 'text-red-500';
-    if (isNegative) return 'text-blue-500';
-    return 'text-gray-500';
-  };
-
-  const formattedPreviousClose = previousClose.toLocaleString();
-  const formattedPriceChange = Math.abs(priceChange).toFixed(2);
-  const priceChangeSymbol = isPositive ? '+' : isNegative ? '-' : '';
+export default function SearchCard() {
+  const companyName = '회사명';
+  const previousClose = 50000;
+  const priceChange = 2.5;
 
   return (
     <li className='h-[52px] w-full rounded-xl hover:cursor-pointer hover:bg-gray-50'>
@@ -33,14 +14,11 @@ export default function SearchCard({
 
         <div className='flex flex-col items-end justify-center gap-0.5'>
           <p className='text-right text-sm font-medium text-gray-900'>
-            {formattedPreviousClose}
+            {previousClose.toLocaleString()}
           </p>
 
-          <p
-            className={`text-right text-xs font-medium ${getPriceChangeColor()}`}
-          >
-            {priceChangeSymbol}
-            {formattedPriceChange}%
+          <p className={'text-right text-xs font-medium text-red-500'}>
+            +{Math.abs(priceChange).toFixed(2)}%
           </p>
         </div>
       </div>

--- a/FE/src/components/Search/SearchCard.tsx
+++ b/FE/src/components/Search/SearchCard.tsx
@@ -1,0 +1,49 @@
+type SearchCardProps = {
+  companyName: string;
+  previousClose: number;
+  priceChange: number;
+};
+
+export default function SearchCard({
+  companyName = '회사명',
+  previousClose = 50000,
+  priceChange = 2.5,
+}: SearchCardProps) {
+  const isPositive = priceChange > 0;
+  const isNegative = priceChange < 0;
+
+  const getPriceChangeColor = () => {
+    if (isPositive) return 'text-red-500';
+    if (isNegative) return 'text-blue-500';
+    return 'text-gray-500';
+  };
+
+  const formattedPreviousClose = previousClose.toLocaleString();
+  const formattedPriceChange = Math.abs(priceChange).toFixed(2);
+  const priceChangeSymbol = isPositive ? '+' : isNegative ? '-' : '';
+
+  return (
+    <li className='h-[52px] w-full rounded-xl hover:cursor-pointer hover:bg-gray-50'>
+      <div className='my-2 flex w-full items-center justify-between px-4'>
+        <div className='flex-1'>
+          <p className='text-left font-medium text-juga-grayscale-black'>
+            {companyName}
+          </p>
+        </div>
+
+        <div className='flex flex-col items-end justify-center gap-0.5'>
+          <p className='text-right text-sm font-medium text-gray-900'>
+            {formattedPreviousClose}
+          </p>
+
+          <p
+            className={`text-right text-xs font-medium ${getPriceChangeColor()}`}
+          >
+            {priceChangeSymbol}
+            {formattedPriceChange}%
+          </p>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/FE/src/components/Search/SearchHistoryList.tsx
+++ b/FE/src/components/Search/SearchHistoryList.tsx
@@ -10,7 +10,7 @@ export function SearchHistoryList({
   onDeleteItem,
 }: SearchHistoryListProps) {
   return (
-    <div className={'flex w-full flex-col'}>
+    <div className={'flex w-full flex-col pb-2'}>
       <div className={'mb-2 flex items-center justify-between'}>
         <div className={'text-start text-sm font-bold'}>최근 검색</div>
       </div>

--- a/FE/src/components/Search/SearchInput.tsx
+++ b/FE/src/components/Search/SearchInput.tsx
@@ -1,4 +1,5 @@
 import { MagnifyingGlassIcon } from '@heroicons/react/16/solid';
+import { useEffect, useRef } from 'react';
 
 interface SearchInputProps {
   value: string;
@@ -6,6 +7,12 @@ interface SearchInputProps {
 }
 
 export function SearchInput({ value, onChange }: SearchInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
   return (
     <div
       className={
@@ -14,6 +21,7 @@ export function SearchInput({ value, onChange }: SearchInputProps) {
     >
       <MagnifyingGlassIcon className={'ml-3 h-4 w-4 fill-juga-grayscale-200'} />
       <input
+        ref={inputRef}
         className={
           'h-[36px] w-full rounded-lg bg-juga-grayscale-50 py-2 pl-[10px] pr-10 text-sm font-normal focus:outline-none'
         }

--- a/FE/src/components/Search/SearchList.tsx
+++ b/FE/src/components/Search/SearchList.tsx
@@ -1,0 +1,16 @@
+import SearchCard from './SearchCard.tsx';
+
+export default function SearchList() {
+  return (
+    <>
+      <div className={'my-4 flex items-center justify-between'}>
+        <div className={'text-start text-sm font-bold'}>검색 결과</div>
+      </div>
+      <ul className='flex h-full w-full flex-col items-center justify-between overflow-y-auto'>
+        {Array.from({ length: 30 }, (_, index) => {
+          return <SearchCard key={index} />;
+        })}
+      </ul>
+    </>
+  );
+}

--- a/FE/src/components/Search/index.tsx
+++ b/FE/src/components/Search/index.tsx
@@ -3,6 +3,7 @@ import useSearchModalStore from '../../store/useSearchModalStore';
 import Overlay from '../../utils/ModalOveray';
 import { SearchInput } from './SearchInput';
 import { SearchHistoryList } from './SearchHistoryList';
+import SearchList from './SearchList.tsx';
 
 export default function SearchModal() {
   const { isOpen, toggleSearchModal } = useSearchModalStore();
@@ -22,13 +23,26 @@ export default function SearchModal() {
   return (
     <>
       <Overlay onClick={() => toggleSearchModal()} />
-      <section className='fixed left-1/2 top-3 flex w-[640px] -translate-x-1/2 flex-col rounded-2xl bg-white shadow-lg'>
-        <div className={'flex flex-col gap-5 p-3'}>
-          <SearchInput value={searchTerm} onChange={setSearchTerm} />
-          <SearchHistoryList
-            searchHistory={searchHistory}
-            onDeleteItem={handleDeleteHistoryItem}
-          />
+      <section
+        className={`${searchTerm === '' ? '' : 'h-[520px]'} fixed left-1/2 top-3 flex w-[640px] -translate-x-1/2 flex-col rounded-2xl bg-white shadow-lg`}
+      >
+        <div className='flex h-full flex-col p-3'>
+          <div className='mb-5'>
+            <SearchInput value={searchTerm} onChange={setSearchTerm} />
+          </div>
+          <div className='flex-1 overflow-hidden'>
+            <SearchHistoryList
+              searchHistory={searchHistory}
+              onDeleteItem={handleDeleteHistoryItem}
+            />
+            {searchTerm === '' ? (
+              <></>
+            ) : (
+              <div className='h-full overflow-y-auto'>
+                <SearchList />
+              </div>
+            )}
+          </div>
         </div>
       </section>
     </>

--- a/FE/src/components/Search/index.tsx
+++ b/FE/src/components/Search/index.tsx
@@ -4,10 +4,11 @@ import Overlay from '../../utils/ModalOveray';
 import { SearchInput } from './SearchInput';
 import { SearchHistoryList } from './SearchHistoryList';
 import SearchList from './SearchList.tsx';
+import useSearchInputStore from '../../store/useSearchInputStore.ts';
 
 export default function SearchModal() {
   const { isOpen, toggleSearchModal } = useSearchModalStore();
-  const [searchTerm, setSearchTerm] = useState('');
+  const { searchInput, setSearchInput } = useSearchInputStore();
   const [searchHistory, setSearchHistory] = useState<string[]>([]);
 
   useEffect(() => {
@@ -24,18 +25,18 @@ export default function SearchModal() {
     <>
       <Overlay onClick={() => toggleSearchModal()} />
       <section
-        className={`${searchTerm === '' ? '' : 'h-[520px]'} fixed left-1/2 top-3 flex w-[640px] -translate-x-1/2 flex-col rounded-2xl bg-white shadow-lg`}
+        className={`${searchInput === '' ? '' : 'h-[520px]'} fixed left-1/2 top-3 flex w-[640px] -translate-x-1/2 flex-col rounded-2xl bg-white shadow-lg`}
       >
         <div className='flex h-full flex-col p-3'>
           <div className='mb-5'>
-            <SearchInput value={searchTerm} onChange={setSearchTerm} />
+            <SearchInput value={searchInput} onChange={setSearchInput} />
           </div>
           <div className='flex-1 overflow-hidden'>
             <SearchHistoryList
               searchHistory={searchHistory}
               onDeleteItem={handleDeleteHistoryItem}
             />
-            {searchTerm === '' ? (
+            {searchInput === '' ? (
               <></>
             ) : (
               <div className='h-full overflow-y-auto'>

--- a/FE/src/components/TopFive/Nav.tsx
+++ b/FE/src/components/TopFive/Nav.tsx
@@ -43,7 +43,7 @@ export default function Nav() {
           key={market}
           ref={(el) => (buttonRefs.current[index] = el)}
           onClick={() => handleMarketChange(market)}
-          className={`relative px-2 py-2`}
+          className={'relative px-2 py-2'}
         >
           {market}
         </button>

--- a/FE/src/page/Home.tsx
+++ b/FE/src/page/Home.tsx
@@ -1,6 +1,5 @@
 import TopFive from 'components/TopFive/TopFive';
 import StockIndex from 'components/StockIndex/index.tsx';
-import SearchModal from '../components/Search';
 
 export default function Home() {
   return (

--- a/FE/src/store/useSearchInputStore.ts
+++ b/FE/src/store/useSearchInputStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+interface SearchInputStore {
+  searchInput: string;
+  setSearchInput: (input: string) => void;
+  resetSearchInput: () => void;
+}
+
+const useSearchInputStore = create<SearchInputStore>((set) => ({
+  searchInput: '',
+
+  setSearchInput: (input: string) => {
+    set({ searchInput: input });
+  },
+
+  resetSearchInput: () => {
+    set({ searchInput: '' });
+  },
+}));
+
+export default useSearchInputStore;


### PR DESCRIPTION
두 가지 PR 템플릿 중 하나를 골라 작성하시면 됩니다!
### ✅ 주요 작업
- 검색 레이아웃 구현.
- UX개선.
- zustand 적용.

https://github.com/user-attachments/assets/b0ac5cf4-3188-4ad0-9b27-63be38553a4a


### 💭 고민과 해결과정
- 검색에서 입력을 한 이후 외부로 나왔을 때 헤더에 표시가 되지 않았다. 이부분은 UX에 안좋다고 생각했다. 따라서 zustand를 이용해 사용자 input 값을 저장한 이후 이를 헤더에 적용하는 방식으로 수정했다.
- 검색창을 출렀을 때 나오는 모달에서 바로 input테그로 포커스가 이동하지 않아서 UX에 좋지 않다고 생각했다. 따라서 검색 모달이 열리면 바로 input으로 포커스가 가도록 수정했다.

---
### 📊 FE/BE 전체 작업 내역
- #62 
