### PR TITLE
[BE] socket 분리 로직 수정

### DIFF
--- a/BE/src/stock/index/stock-index.module.ts
+++ b/BE/src/stock/index/stock-index.module.ts
@@ -8,6 +8,5 @@ import { SocketModule } from '../../websocket/socket.module';
   imports: [KoreaInvestmentModule, SocketModule],
   controllers: [StockIndexController],
   providers: [StockIndexService],
-  exports: [StockIndexService],
 })
 export class StockIndexModule {}

--- a/BE/src/stock/order/stock-order.controller.ts
+++ b/BE/src/stock/order/stock-order.controller.ts
@@ -22,7 +22,7 @@ import { RequestInterface } from './interface/request.interface';
 @Controller('/api/stocks/trade')
 @ApiTags('주식 매수/매도 API')
 export class StockOrderController {
-  constructor(private readonly stockTradeService: StockOrderService) {}
+  constructor(private readonly stockOrderService: StockOrderService) {}
 
   @Post('/buy')
   @ApiBearerAuth()
@@ -39,7 +39,7 @@ export class StockOrderController {
     @Req() request: RequestInterface,
     @Body(ValidationPipe) stockOrderRequest: StockOrderRequestDto,
   ) {
-    await this.stockTradeService.buy(request.user.id, stockOrderRequest);
+    await this.stockOrderService.buy(request.user.id, stockOrderRequest);
   }
 
   @Post('/sell')
@@ -57,7 +57,7 @@ export class StockOrderController {
     @Req() request: RequestInterface,
     @Body(ValidationPipe) stockOrderRequest: StockOrderRequestDto,
   ) {
-    await this.stockTradeService.sell(request.user.id, stockOrderRequest);
+    await this.stockOrderService.sell(request.user.id, stockOrderRequest);
   }
 
   @Delete('/:order_id')
@@ -75,6 +75,6 @@ export class StockOrderController {
     @Req() request: RequestInterface,
     @Param('order_id') orderId: number,
   ) {
-    await this.stockTradeService.cancel(request.user.id, orderId);
+    await this.stockOrderService.cancel(request.user.id, orderId);
   }
 }

--- a/BE/src/websocket/base-socket.service.ts
+++ b/BE/src/websocket/base-socket.service.ts
@@ -1,17 +1,22 @@
 import { WebSocket } from 'ws';
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  OnModuleInit,
+} from '@nestjs/common';
 import { SocketGateway } from './socket.gateway';
 import { SocketTokenService } from './socket-token.service';
 
 @Injectable()
-export abstract class BaseSocketService implements OnModuleInit {
-  protected socket: WebSocket;
-  protected socketConnectionKey: string;
+export class BaseSocketService implements OnModuleInit {
+  private socket: WebSocket;
+  private socketConnectionKey: string;
+  private socketOpenHandlers: (() => void | Promise<void>)[] = [];
+  private socketDataHandlers: {
+    [key: string]: (data) => void;
+  } = {};
 
-  constructor(
-    protected readonly socketTokenService: SocketTokenService,
-    protected readonly socketGateway: SocketGateway,
-  ) {}
+  constructor(private readonly socketTokenService: SocketTokenService) {}
 
   async onModuleInit() {
     this.socketConnectionKey =
@@ -19,7 +24,13 @@ export abstract class BaseSocketService implements OnModuleInit {
     this.socket = new WebSocket(process.env.KOREA_INVESTMENT_SOCKET_URL);
 
     this.socket.onopen = () => {
-      this.handleSocketOpen();
+      Promise.all(
+        this.socketOpenHandlers.map(async (socketOpenHandler) => {
+          await socketOpenHandler();
+        }),
+      ).catch(() => {
+        throw new InternalServerErrorException();
+      });
     };
 
     this.socket.onmessage = (event) => {
@@ -30,14 +41,11 @@ export abstract class BaseSocketService implements OnModuleInit {
       if (data.length < 2) return;
 
       const dataList = data[3].split('^');
-      this.handleSocketData(dataList);
+      this.socketDataHandlers[data[1]](dataList);
     };
   }
 
-  protected abstract handleSocketOpen(): void;
-  protected abstract handleSocketData(dataList): void;
-
-  protected registerCode(trId: string, trKey: string) {
+  registerCode(trId: string, trKey: string) {
     this.socket.send(
       JSON.stringify({
         header: {
@@ -54,5 +62,13 @@ export abstract class BaseSocketService implements OnModuleInit {
         },
       }),
     );
+  }
+
+  registerSocketOpenHandler(handler: () => void | Promise<void>) {
+    this.socketOpenHandlers.push(handler);
+  }
+
+  registerSocketDataHandler(tradeCode: string, handler: (data) => void) {
+    this.socketDataHandlers[tradeCode] = handler;
   }
 }

--- a/BE/src/websocket/base-socket.service.ts
+++ b/BE/src/websocket/base-socket.service.ts
@@ -4,7 +4,6 @@ import {
   InternalServerErrorException,
   OnModuleInit,
 } from '@nestjs/common';
-import { SocketGateway } from './socket.gateway';
 import { SocketTokenService } from './socket-token.service';
 
 @Injectable()

--- a/BE/src/websocket/socket.module.ts
+++ b/BE/src/websocket/socket.module.ts
@@ -2,11 +2,20 @@ import { Module } from '@nestjs/common';
 import { StockIndexSocketService } from './stock-index-socket.service';
 import { SocketGateway } from './socket.gateway';
 import { SocketTokenService } from './socket-token.service';
+import { StockPriceSocketService } from './stock/price/stock-price-socket.service';
+import { StockItemModule } from '../stock/item/stock-item.module';
+import { BaseSocketService } from './base-socket.service';
 
 @Module({
-  imports: [],
+  imports: [StockItemModule],
   controllers: [],
-  providers: [SocketTokenService, StockIndexSocketService, SocketGateway],
+  providers: [
+    SocketTokenService,
+    StockIndexSocketService,
+    SocketGateway,
+    StockPriceSocketService,
+    BaseSocketService,
+  ],
   exports: [SocketGateway],
 })
 export class SocketModule {}

--- a/BE/src/websocket/socket.module.ts
+++ b/BE/src/websocket/socket.module.ts
@@ -2,18 +2,15 @@ import { Module } from '@nestjs/common';
 import { StockIndexSocketService } from './stock-index-socket.service';
 import { SocketGateway } from './socket.gateway';
 import { SocketTokenService } from './socket-token.service';
-import { StockPriceSocketService } from './stock/price/stock-price-socket.service';
-import { StockItemModule } from '../stock/item/stock-item.module';
 import { BaseSocketService } from './base-socket.service';
 
 @Module({
-  imports: [StockItemModule],
+  imports: [],
   controllers: [],
   providers: [
     SocketTokenService,
     StockIndexSocketService,
     SocketGateway,
-    StockPriceSocketService,
     BaseSocketService,
   ],
   exports: [SocketGateway],

--- a/BE/src/websocket/stock-index-socket.service.ts
+++ b/BE/src/websocket/stock-index-socket.service.ts
@@ -29,7 +29,12 @@ export class StockIndexSocketService {
       (data: string[]) => {
         this.socketGateway.sendStockIndexValueToClient(
           this.STOCK_CODE[data[0]],
-          new StockIndexValueElementDto(data[2], data[4], data[9], data[3]),
+          new StockIndexValueElementDto(
+            data[2], // 주가 지수
+            data[4], // 전일 대비 등락
+            data[9], // 전일 대비 등락률
+            data[3], // 부호
+          ),
         );
       },
     );

--- a/BE/src/websocket/stock-index-socket.service.ts
+++ b/BE/src/websocket/stock-index-socket.service.ts
@@ -5,7 +5,7 @@ import { SocketGateway } from './socket.gateway';
 
 @Injectable()
 export class StockIndexSocketService {
-  private TRADE_CODE = 'H0UPCNT0';
+  private TR_ID = 'H0UPCNT0';
   private STOCK_CODE = {
     '0001': 'KOSPI',
     '1001': 'KOSDAQ',
@@ -18,14 +18,14 @@ export class StockIndexSocketService {
     private readonly baseSocketService: BaseSocketService,
   ) {
     baseSocketService.registerSocketOpenHandler(() => {
-      this.baseSocketService.registerCode(this.TRADE_CODE, '0001'); // 코스피
-      this.baseSocketService.registerCode(this.TRADE_CODE, '1001'); // 코스닥
-      this.baseSocketService.registerCode(this.TRADE_CODE, '2001'); // 코스피200
-      this.baseSocketService.registerCode(this.TRADE_CODE, '3003'); // KSQ150
+      this.baseSocketService.registerCode(this.TR_ID, '0001'); // 코스피
+      this.baseSocketService.registerCode(this.TR_ID, '1001'); // 코스닥
+      this.baseSocketService.registerCode(this.TR_ID, '2001'); // 코스피200
+      this.baseSocketService.registerCode(this.TR_ID, '3003'); // KSQ150
     });
 
     baseSocketService.registerSocketDataHandler(
-      this.TRADE_CODE,
+      this.TR_ID,
       (data: string[]) => {
         this.socketGateway.sendStockIndexValueToClient(
           this.STOCK_CODE[data[0]],


### PR DESCRIPTION
### ✅ 주요 작업
- [x] onModuleInit이 한번만 실행되도록 로직 수정

### 💭 고민과 해결과정
- BaseSocketService를 extend 하고 싶었지만... onModuleInit이 여러번 실행되어 소켓 세션이 여러개 연결되는 문제가 발생했다. 한투에서는 소켓 세션을 하나만 허용하고 있기 때문에, 연결 오류가 발생해 전체적으로 로직을 수정했다.

