### PR TITLE
[BE] 6.04 매수/매도 요청 현황 API 구현

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -12,6 +12,7 @@ import { SocketModule } from './websocket/socket.module';
 import { StockOrderModule } from './stock/order/stock-order.module';
 import { StockDetailModule } from './stock/detail/stock-detail.module';
 import { typeOrmConfig } from './configs/typeorm.config';
+import { StockTradeHistoryModule } from './stock/trade/history/stock-trade-history.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { typeOrmConfig } from './configs/typeorm.config';
     SocketModule,
     StockDetailModule,
     StockOrderModule,
+    StockTradeHistoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BE/src/stock/trade/history/dto/stock-trade-history-data.dto.ts
+++ b/BE/src/stock/trade/history/dto/stock-trade-history-data.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StockTradeHistoryDataDto {
+  @ApiProperty({ description: '주식 체결 시간' })
+  stck_cntg_hour: string;
+
+  @ApiProperty({ description: '주식 현재가' })
+  stck_prpr: string;
+
+  @ApiProperty({ description: '전일 대비 부호' })
+  prdy_vrss_sign: string;
+
+  @ApiProperty({ description: '체결 거래량' })
+  cntg_vol: string;
+
+  @ApiProperty({ description: '전일 대비율' })
+  prdy_ctrt: string;
+}

--- a/BE/src/stock/trade/history/dto/stock-trade-history-output.dto.ts
+++ b/BE/src/stock/trade/history/dto/stock-trade-history-output.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StockTradeHistoryOutputDto {
+  @ApiProperty({ description: '주식 체결 시간' })
+  stck_cntg_hour: string;
+
+  @ApiProperty({ description: '주식 현재가' })
+  stck_prpr: string;
+
+  @ApiProperty({ description: '전일 대비' })
+  prdy_vrss: string;
+
+  @ApiProperty({ description: '전일 대비 부호' })
+  prdy_vrss_sign: string;
+
+  @ApiProperty({ description: '체결 거래량' })
+  cntg_vol: string;
+
+  @ApiProperty({ description: '당일 체결강도' })
+  tday_rltv: string;
+
+  @ApiProperty({ description: '전일 대비율' })
+  prdy_ctrt: string;
+}

--- a/BE/src/stock/trade/history/dto/stock-trade-history-query-parameter.dto.ts
+++ b/BE/src/stock/trade/history/dto/stock-trade-history-query-parameter.dto.ts
@@ -1,0 +1,16 @@
+/**
+ * 주식현재가 체결 API를 사용할 때 쿼리 파라미터로 사용할 요청값 DTO
+ */
+export class StockTradeHistoryQueryParameterDto {
+  /**
+   * 조건 시장 분류 코드
+   * 'J' 주식
+   */
+  fid_cond_mrkt_div_code: string;
+
+  /**
+   * 주식 종목 코드
+   * (ex) 005930
+   */
+  fid_input_iscd: string;
+}

--- a/BE/src/stock/trade/history/dto/stock-trade-history-response.dto.ts
+++ b/BE/src/stock/trade/history/dto/stock-trade-history-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { StockTradeHistoryOutputDto } from './stock-trade-history-output.dto';
+
+/**
+ * 주식현재가 체결 API 응답값 정제 후 FE에 보낼 DTO
+ */
+export class StockTradeHistoryResponseDto {
+  @ApiProperty({ type: StockTradeHistoryOutputDto, description: '상승률 순위' })
+  output: StockTradeHistoryOutputDto[];
+}

--- a/BE/src/stock/trade/history/interface/Inquire-ccnl.interface.ts
+++ b/BE/src/stock/trade/history/interface/Inquire-ccnl.interface.ts
@@ -1,0 +1,16 @@
+export interface InquireCCNLOutputData {
+  stck_cntg_hour: string;
+  stck_prpr: string;
+  prdy_vrss: string;
+  prdy_vrss_sign: string;
+  cntg_vol: string;
+  tday_rltv: string;
+  prdy_ctrt: string;
+}
+
+export interface InquireCCNLApiResponse {
+  output: InquireCCNLOutputData[];
+  rt_cd: string;
+  msg_cd: string;
+  msg1: string;
+}

--- a/BE/src/stock/trade/history/stock-trade-history.controller.ts
+++ b/BE/src/stock/trade/history/stock-trade-history.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { StockTradeHistoryService } from './stock-trade-history.service';
+import { StockTradeHistoryResponseDto } from './dto/stock-trade-history-response.dto';
+
+@Controller('/api/stocks')
+export class StockTradeHistoryController {
+  constructor(
+    private readonly stockTradeHistoryService: StockTradeHistoryService,
+  ) {}
+
+  @Get(':stockCode/trade-history')
+  @ApiOperation({ summary: '단일 주식 종목에 대한 주식현재가 체결 API' })
+  @ApiParam({
+    name: 'stockCode',
+    required: true,
+    description:
+      '종목 코드\n\n' +
+      '(ex) 005930 삼성전자 / 005380 현대차 / 001500 현대차증권',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '단일 주식 종목에 대한 주식현재가 체결값 조회 성공',
+    type: StockTradeHistoryResponseDto,
+  })
+  getStockDetail(@Param('stockCode') stockCode: string) {
+    return this.stockTradeHistoryService.getStockTradeHistory(stockCode);
+  }
+}

--- a/BE/src/stock/trade/history/stock-trade-history.module.ts
+++ b/BE/src/stock/trade/history/stock-trade-history.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { KoreaInvestmentModule } from '../../../koreaInvestment/korea-investment.module';
+import { StockTradeHistoryController } from './stock-trade-history.controller';
+import { StockTradeHistoryService } from './stock-trade-history.service';
+
+@Module({
+  imports: [KoreaInvestmentModule],
+  controllers: [StockTradeHistoryController],
+  providers: [StockTradeHistoryService],
+})
+export class StockTradeHistoryModule {}

--- a/BE/src/stock/trade/history/stock-trade-history.service.ts
+++ b/BE/src/stock/trade/history/stock-trade-history.service.ts
@@ -1,0 +1,110 @@
+import axios from 'axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { KoreaInvestmentService } from '../../../koreaInvestment/korea-investment.service';
+import { getHeader } from '../../../util/get-header';
+import { getFullURL } from '../../../util/get-full-URL';
+import { StockTradeHistoryQueryParameterDto } from './dto/stock-trade-history-query-parameter.dto';
+import { InquireCCNLApiResponse } from './interface/Inquire-ccnl.interface';
+import { StockTradeHistoryOutputDto } from './dto/stock-trade-history-output.dto';
+import { StockTradeHistoryDataDto } from './dto/stock-trade-history-data.dto';
+
+@Injectable()
+export class StockTradeHistoryService {
+  private readonly logger = new Logger();
+
+  constructor(private readonly koreaInvetmentService: KoreaInvestmentService) {}
+
+  /**
+   * 특정 주식의 현재가 체결 데이터를 반환하는 함수
+   * @param {string} stockCode - 종목코드
+   * @returns - 특정 주식의 현재가 체결 데이터 객체 반환
+   *
+   * @author uuuo3o
+   */
+  async getStockTradeHistory(stockCode: string) {
+    try {
+      const queryParams = new StockTradeHistoryQueryParameterDto();
+      queryParams.fid_cond_mrkt_div_code = 'J';
+      queryParams.fid_input_iscd = stockCode;
+
+      const response = await this.requestApi(queryParams);
+
+      return this.formatTradeHistoryData(response.output);
+    } catch (error) {
+      this.logger.error('API Error Details:', {
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+        headers: error.response?.config?.headers, // 실제 요청 헤더
+        message: error.message,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * @private 한국투자 Open API - [국내주식] 기본시세 - 주식현재가 체결 호출 함수
+   * @param {StockTradeHistoryQueryParameterDto} queryParams - API 요청 시 필요한 쿼리 파라미터 DTO
+   * @returns - 주식현재가 체결 데이터
+   *
+   * @author uuuo3o
+   */
+  private async requestApi(queryParams: StockTradeHistoryQueryParameterDto) {
+    try {
+      const accessToken = await this.koreaInvetmentService.getAccessToken();
+      const headers = getHeader(accessToken, 'FHKST01010300');
+      const url = getFullURL('/uapi/domestic-stock/v1/quotations/inquire-ccnl');
+      const params = this.getTradeHistoryParams(queryParams);
+
+      const response = await axios.get<InquireCCNLApiResponse>(url, {
+        headers,
+        params,
+      });
+
+      return response.data;
+    } catch (error) {
+      this.logger.error('API Error Details:', {
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+        headers: error.response?.config?.headers,
+        message: error.message,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * @private API에서 받은 주식현재가 체결 데이터를 필요한 정보로 정제하는 함수
+   * @param {StockTradeHistoryOutputDto} infos - API 응답에서 받은 원시 데이터
+   * @returns - 필요한 정보만 추출한 데이터 배열
+   *
+   * @author uuuo3o
+   */
+  private formatTradeHistoryData(infos: StockTradeHistoryOutputDto[]) {
+    return infos.map((info) => {
+      const infoData = new StockTradeHistoryDataDto();
+      infoData.stck_cntg_hour = info.stck_cntg_hour;
+      infoData.stck_prpr = info.stck_prpr;
+      infoData.prdy_vrss_sign = info.prdy_vrss_sign;
+      infoData.cntg_vol = info.cntg_vol;
+      infoData.prdy_ctrt = info.prdy_ctrt;
+
+      return infoData;
+    });
+  }
+
+  /**
+   * @private 주식현재가 체결 요청을 위한 쿼리 파라미터 객체 생성 함수
+   * @param {StockTradeHistoryQueryParameterDto} params - API 요청에 필요한 쿼리 파라미터 DTO
+   * @returns - API 요청에 필요한 쿼리 파라미터 객체
+   *
+   * @author uuuo3o
+   */
+  private getTradeHistoryParams(params: StockTradeHistoryQueryParameterDto) {
+    return {
+      fid_cond_mrkt_div_code: params.fid_cond_mrkt_div_code,
+      fid_input_iscd: params.fid_input_iscd,
+    };
+  }
+}


### PR DESCRIPTION
### ✅ 주요 작업
- 주식현재가 체결 API를 활용해 detail 페이지 하단에 있는 실시간 체결 정보 api 구현

### 💭 고민과 해결과정
- 내일 FE분과 이야기해봐야 하는 내용들
  - 피그마 이미지에는 **`거래량(주)`** 부분이 있어서 전체 거래량을 표시해줘야 하는데, 내가 사용한 API에는 해당 부분이 존재하지 않는다.
  - 아래처럼 토스에서는 장 마감 이후에도 이런 체결과 관련된 정보들이 올라오는데 이런 값도 필요한지 여쭤봐야한다!
![image](https://github.com/user-attachments/assets/0ecddecb-69af-4a02-86ed-aa7013551b04)
