### PR TITLE
[BE] 소켓 연결 끊기는 현상 수정

### DIFF
--- a/BE/src/websocket/base-socket.service.ts
+++ b/BE/src/websocket/base-socket.service.ts
@@ -48,6 +48,7 @@ export class BaseSocketService implements OnModuleInit {
             `한국투자증권 웹소켓 연결: ${json.body.msg1}`,
             json.header.tr_id,
           );
+        if (json.header.tr_id === 'PINGPONG') this.socket.pong(json);
         return;
       }
 

--- a/BE/src/websocket/base-socket.service.ts
+++ b/BE/src/websocket/base-socket.service.ts
@@ -59,6 +59,10 @@ export class BaseSocketService implements OnModuleInit {
 
       this.socketDataHandlers[data[1]](dataList);
     };
+
+    this.socket.onclose = () => {
+      this.logger.warn(`한국투자증권 소켓 연결 종료`);
+    };
   }
 
   registerCode(trId: string, trKey: string) {


### PR DESCRIPTION
### ✅ 주요 작업
- [x] pong 데이터 한투 서버로 보내서 소켓 연결 끊김 현상 해결 (아침에 일어나면 소켓 안되는 현상 아마 해결...)

### 💭 고민과 해결과정
**PINGPONG**
한투에서 PINGPONG 데이터 보내서 자동으로 소켓 연결 끊김 해결해주는 줄 알았는데, 한투 서버에서는 PING만 해주고 우리 서버에서 한투 서버로 PONG까지 해줘야 연결이 유지가 되는 방식이었다.

![image](https://github.com/user-attachments/assets/29659956-4d91-4fe1-bfba-b2d566b62232)

위 이미지 참고해서 장 마감 시에 PINGPONG 데이터가 들어오면 pong 응답을 해주도록 아래와 같이 수정했다.
아직 장 마감이 안돼서 테스트는 못해본 상황이다.
```javascript
        if (json.header.tr_id === 'PINGPONG') this.socket.pong(json);
```

> 장 마감되면 테스트 해보고 머지하겠습니다.