### PR TITLE
[BE] 6.02 각 주식 정보 가져오기 API 구현 #54

### DIFF
--- a/BE/src/stock/detail/stock-detail.entity.ts
+++ b/BE/src/stock/detail/stock-detail.entity.ts
@@ -1,0 +1,13 @@
+import { BaseEntity, Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity()
+export class Stocks extends BaseEntity {
+  @PrimaryColumn()
+  code: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  market: string;
+}

--- a/BE/src/stock/detail/stock-detail.module.ts
+++ b/BE/src/stock/detail/stock-detail.module.ts
@@ -1,11 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { KoreaInvestmentModule } from '../../koreaInvestment/korea-investment.module';
 import { StockDetailController } from './stock-detail.controller';
 import { StockDetailService } from './stock-detail.service';
+import { StockDetailRepository } from './stock-detail.repository';
+import { Stocks } from './stock-detail.entity';
 
 @Module({
-  imports: [KoreaInvestmentModule],
+  imports: [KoreaInvestmentModule, TypeOrmModule.forFeature([Stocks])],
   controllers: [StockDetailController],
-  providers: [StockDetailService],
+  providers: [StockDetailService, StockDetailRepository],
 })
 export class StockDetailModule {}

--- a/BE/src/stock/detail/stock-detail.repository.ts
+++ b/BE/src/stock/detail/stock-detail.repository.ts
@@ -1,0 +1,15 @@
+import { InjectDataSource } from '@nestjs/typeorm';
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Stocks } from './stock-detail.entity';
+
+@Injectable()
+export class StockDetailRepository extends Repository<Stocks> {
+  constructor(@InjectDataSource() dataSource: DataSource) {
+    super(Stocks, dataSource.createEntityManager());
+  }
+
+  async findOneByCode(code: string) {
+    return this.findOne({ where: { code } });
+  }
+}

--- a/BE/src/stock/detail/stock-detail.service.ts
+++ b/BE/src/stock/detail/stock-detail.service.ts
@@ -10,12 +10,16 @@ import {
   InquirePriceOutputData,
 } from './interface/stock-detail.interface';
 import { InquirePriceResponseDto } from './dto/stock-detail-response.dto';
+import { StockDetailRepository } from './stock-detail.repository';
 
 @Injectable()
 export class StockDetailService {
   private readonly logger = new Logger();
 
-  constructor(private readonly koreaInvetmentService: KoreaInvestmentService) {}
+  constructor(
+    private readonly koreaInvetmentService: KoreaInvestmentService,
+    private readonly stockDetailRepository: StockDetailRepository,
+  ) {}
 
   /**
    * 주식현재가 시세 데이터를 반환하는 함수
@@ -57,16 +61,23 @@ export class StockDetailService {
    *
    * @author uuuo3o
    */
-  private formatStockData(stock: InquirePriceOutputData) {
-    const stockData = new InquirePriceResponseDto();
-    stockData.stck_shrn_iscd = stock.stck_shrn_iscd;
-    stockData.stck_prpr = stock.stck_prpr;
-    stockData.prdy_vrss = stock.prdy_vrss;
-    stockData.prdy_vrss_sign = stock.prdy_vrss_sign;
-    stockData.prdy_ctrt = stock.prdy_ctrt;
-    stockData.hts_avls = stock.hts_avls;
-    stockData.per = stock.per;
-    return stockData;
+  private async formatStockData(
+    stock: InquirePriceOutputData,
+  ): Promise<InquirePriceResponseDto> {
+    const { name } = await this.stockDetailRepository.findOneByCode(
+      stock.stck_shrn_iscd,
+    );
+
+    return {
+      hts_kor_isnm: name,
+      stck_shrn_iscd: stock.stck_shrn_iscd,
+      stck_prpr: stock.stck_prpr,
+      prdy_vrss: stock.prdy_vrss,
+      prdy_vrss_sign: stock.prdy_vrss_sign,
+      prdy_ctrt: stock.prdy_ctrt,
+      hts_avls: stock.hts_avls,
+      per: stock.per,
+    };
   }
 
   /**


### PR DESCRIPTION
### ✅ 주요 작업
- DB에서 종목 코드를 이용해 한글 종목명을 가져오는 로직 추가

### 💭 고민과 해결과정
- Entity와 Repository가 필요해서 만들었더니 stock-list 부분과 완전 동일한 내용으로 만들어졌습니다. stock-list entity와 repository를 그대로 쓸까하다가 도메인별로 분리되어있는 프로젝트 구조 특성상 너무 어색해서 새로 만들어서 사용했습니다.
- 겹치는 공통 부분을 stock 디렉터리 바로 아래로 옮겨서 함께 사용할 수 있는 방안으로 구상중입니다.