### PR TITLE
[FE] UI 수정 & 차트 디자인 수정.

### DIFF
--- a/FE/src/components/Search/SearchCardHighlight.tsx
+++ b/FE/src/components/Search/SearchCardHighlight.tsx
@@ -11,12 +11,13 @@ export const SearchCardHighLight = ({
     return <div>{text}</div>;
   }
 
-  const parts = text.split(new RegExp(`(${highlight})`, 'gi'));
+  const targetWord = highlight.trim();
 
+  const parts = text.trim().split(new RegExp(`(${targetWord})`, 'gi'));
   return (
     <div>
       {parts.map((part, index) =>
-        part.toLowerCase() === highlight.toLowerCase() ? (
+        part.toLowerCase() === targetWord.toLowerCase() ? (
           <span
             key={`${part}-${index}`}
             className={'font-medium text-juga-blue-50'}

--- a/FE/src/components/Search/searchHistoryHook.ts
+++ b/FE/src/components/Search/searchHistoryHook.ts
@@ -22,7 +22,7 @@ export function useSearchHistory() {
       );
       const newItem: HistoryType = {
         id: `${keyword}-${Date.now()}`,
-        text: keyword,
+        text: keyword.trim(),
         timestamp: new Date().toISOString(),
       };
       const newHistory = [newItem, ...filteredHistory].slice(

--- a/FE/src/components/Search/searchHistoryHook.ts
+++ b/FE/src/components/Search/searchHistoryHook.ts
@@ -17,7 +17,9 @@ export function useSearchHistory() {
     if (!keyword.trim()) return;
 
     setSearchHistory((prev) => {
-      const filteredHistory = prev.filter((item) => item.text !== keyword);
+      const filteredHistory = prev.filter(
+        (item) => item.text.trim() !== keyword.trim(),
+      );
       const newItem: HistoryType = {
         id: `${keyword}-${Date.now()}`,
         text: keyword,

--- a/FE/src/components/StockIndex/Card.tsx
+++ b/FE/src/components/StockIndex/Card.tsx
@@ -22,8 +22,15 @@ export function Card({ name, id, initialData }: StockIndexChartProps) {
     useState<StockIndexValue>(value);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  const changeColor =
-    Number(value.diff) > 0 ? 'text-juga-red-60' : 'text-juga-blue-50';
+  const color =
+    value.sign === '3'
+      ? ''
+      : value.sign < '3'
+        ? 'text-juga-red-60'
+        : 'text-juga-blue-40';
+  const percentAbsolute = Math.abs(Number(value.diff_rate)).toFixed(2);
+
+  const plusOrMinus = value.sign === '3' ? '' : value.sign < '3' ? '+' : '-';
 
   socket.on(id, (stockIndex) => {
     setStockIndexValue(stockIndex);
@@ -46,8 +53,10 @@ export function Card({ name, id, initialData }: StockIndexChartProps) {
       <div className='flex h-full w-[108px] flex-1 flex-col items-start justify-center text-sm'>
         <p className='font-semibold'>{name}</p>
         <p className='text-lg font-bold'>{stockIndexValue.curr_value}</p>
-        <p className={`font-semibold ${changeColor}`}>
-          {stockIndexValue.diff}({stockIndexValue.diff_rate}%)
+        <p className={`font-semibold ${color}`}>
+          {plusOrMinus}
+          {Math.abs(Number(stockIndexValue.diff)).toFixed(2)}({plusOrMinus}
+          {percentAbsolute}%)
         </p>
       </div>
       <canvas

--- a/FE/src/components/StockIndex/Card.tsx
+++ b/FE/src/components/StockIndex/Card.tsx
@@ -55,8 +55,8 @@ export function Card({ name, id, initialData }: StockIndexChartProps) {
         <p className='text-lg font-bold'>{stockIndexValue.curr_value}</p>
         <p className={`font-semibold ${color}`}>
           {plusOrMinus}
-          {Math.abs(Number(stockIndexValue.diff)).toFixed(2)}({plusOrMinus}
-          {percentAbsolute}%)
+          {Math.abs(Number(stockIndexValue.diff)).toFixed(2)}({percentAbsolute}
+          %)
         </p>
       </div>
       <canvas

--- a/FE/src/components/StocksDetail/Chart.tsx
+++ b/FE/src/components/StocksDetail/Chart.tsx
@@ -53,7 +53,7 @@ export default function Chart({ code }: StocksDeatailChartProps) {
 
     const padding = {
       top: 20,
-      right: 80,
+      right: 160,
       bottom: 10,
       left: 20,
     };
@@ -71,10 +71,10 @@ export default function Chart({ code }: StocksDeatailChartProps) {
 
   return (
     <div
-      className='flex flex-col items-center flex-1 p-3 rounded-lg bg-juga-grayscale-50'
+      className='flex flex-1 flex-col items-center rounded-lg bg-juga-grayscale-50 p-3'
       ref={containerRef}
     >
-      <div className='flex items-center justify-between w-full'>
+      <div className='flex w-full items-center justify-between'>
         <p className='font-semibold'>차트</p>
         <nav className='flex gap-4 text-sm'>
           {categories.map(({ label, value }) => (

--- a/FE/src/components/StocksDetail/Header.tsx
+++ b/FE/src/components/StocksDetail/Header.tsx
@@ -35,8 +35,11 @@ export default function Header({ code }: StocksDeatailHeaderProps) {
         ? 'text-juga-red-60'
         : 'text-juga-blue-40';
 
+  const plusOrMinus =
+    prdy_vrss_sign === '3' ? '' : prdy_vrss_sign < '3' ? '+' : '-';
+
   return (
-    <div className='flex items-center justify-between w-full h-16 px-2'>
+    <div className='flex h-16 w-full items-center justify-between px-2'>
       <div className='flex flex-col font-semibold'>
         <div className='flex gap-2 text-sm'>
           <h2>{hts_kor_isnm}</h2>
@@ -46,7 +49,8 @@ export default function Header({ code }: StocksDeatailHeaderProps) {
           <p className='text-lg'>{Number(stck_prpr).toLocaleString()}원</p>
           <p>어제보다</p>
           <p className={`${colorStyleBySign}`}>
-            +{Number(prdy_vrss).toLocaleString()}원 ({prdy_ctrt}%)
+            {plusOrMinus}
+            {Math.abs(Number(prdy_vrss)).toLocaleString()}원 ({prdy_ctrt}%)
           </p>
         </div>
       </div>

--- a/FE/src/components/StocksDetail/Header.tsx
+++ b/FE/src/components/StocksDetail/Header.tsx
@@ -35,6 +35,8 @@ export default function Header({ code }: StocksDeatailHeaderProps) {
         ? 'text-juga-red-60'
         : 'text-juga-blue-40';
 
+  const percentAbsolute = Math.abs(Number(prdy_ctrt)).toFixed(2);
+
   const plusOrMinus =
     prdy_vrss_sign === '3' ? '' : prdy_vrss_sign < '3' ? '+' : '-';
 
@@ -50,7 +52,8 @@ export default function Header({ code }: StocksDeatailHeaderProps) {
           <p>어제보다</p>
           <p className={`${colorStyleBySign}`}>
             {plusOrMinus}
-            {Math.abs(Number(prdy_vrss)).toLocaleString()}원 ({prdy_ctrt}%)
+            {Math.abs(Number(prdy_vrss)).toLocaleString()}원 ({plusOrMinus}
+            {percentAbsolute}%)
           </p>
         </div>
       </div>

--- a/FE/src/components/StocksDetail/PriceDataType.ts
+++ b/FE/src/components/StocksDetail/PriceDataType.ts
@@ -1,9 +1,9 @@
 export type PriceDataType = {
   stck_cntg_hour: string;
-  stck_prpr: 'string';
-  prdy_vrss_sign: 'string';
-  cntg_vol: 'string';
-  prdy_ctrt: 'string';
+  stck_prpr: string;
+  prdy_vrss_sign: string;
+  cntg_vol: string;
+  prdy_ctrt: string;
 };
 
 export type DailyPriceDataType = {

--- a/FE/src/components/StocksDetail/PriceSection.tsx
+++ b/FE/src/components/StocksDetail/PriceSection.tsx
@@ -16,7 +16,7 @@ export default function PriceSection() {
   const { data, isLoading } = useQuery({
     queryKey: ['detail', id, buttonFlag],
     queryFn: () => getTradeHistory(id as string, buttonFlag),
-    refetchInterval: 1000,
+    // refetchInterval: 1000,
     cacheTime: 30000,
     staleTime: 1000,
   });

--- a/FE/src/components/StocksDetail/PriceTableDayCard.tsx
+++ b/FE/src/components/StocksDetail/PriceTableDayCard.tsx
@@ -5,8 +5,16 @@ type PriceTableDayCardProps = {
 };
 
 export default function PriceTableDayCard({ data }: PriceTableDayCardProps) {
-  const percent = Number(data.prdy_ctrt);
-  const color = percent > 0 ? 'text-juga-red-60' : 'text-juga-blue-50';
+  const color =
+    data.prdy_vrss_sign === '3'
+      ? ''
+      : data.prdy_vrss_sign < '3'
+        ? 'text-juga-red-60'
+        : 'text-juga-blue-40';
+  const percentAbsolute = Math.abs(Number(data.prdy_ctrt)).toFixed(2);
+
+  const plusOrMinus =
+    data.prdy_vrss_sign === '3' ? '' : data.prdy_vrss_sign < '3' ? '+' : '-';
   function formatTime(time: string) {
     if (!time.length) return '----.--.--';
     const year = time.slice(0, 4);
@@ -23,7 +31,8 @@ export default function PriceTableDayCard({ data }: PriceTableDayCardProps) {
         {Number(data.stck_clpr).toLocaleString()}
       </td>
       <td className={`px-4 py-1 text-right ${color}`}>
-        {percent > 0 ? `+${percent}%` : `${percent}%`}
+        {plusOrMinus}
+        {percentAbsolute}%
       </td>
       <td className={'px-4 py-1 text-right'}>
         {Number(data.acml_vol).toLocaleString()}

--- a/FE/src/components/StocksDetail/PriceTableLiveCard.tsx
+++ b/FE/src/components/StocksDetail/PriceTableLiveCard.tsx
@@ -4,13 +4,21 @@ type PriceTableLiveCardProps = {
   data: PriceDataType;
 };
 export default function PriceTableLiveCard({ data }: PriceTableLiveCardProps) {
-  const percent = Number(data.prdy_ctrt);
-  const color = percent > 0 ? 'text-juga-red-60' : 'text-juga-blue-50';
+  const color =
+    data.prdy_vrss_sign === '3'
+      ? ''
+      : data.prdy_vrss_sign < '3'
+        ? 'text-juga-red-60'
+        : 'text-juga-blue-40';
+  const percentAbsolute = Math.abs(Number(data.prdy_ctrt)).toFixed(2);
+
+  const plusOrMinus =
+    data.prdy_vrss_sign === '3' ? '' : data.prdy_vrss_sign < '3' ? '+' : '-';
   function formatTime(time: string) {
     const hour = time.slice(0, 2);
     const min = time.slice(2, 4);
     const sec = time.slice(4, 6);
-    return `${hour}.${min}.${sec}`;
+    return `${hour}:${min}:${sec}`;
   }
   return (
     <tr className={'h-[30px] hover:bg-juga-grayscale-50'}>
@@ -19,7 +27,8 @@ export default function PriceTableLiveCard({ data }: PriceTableLiveCardProps) {
       </td>
       <td className={'px-4 py-1 text-right'}>{data.cntg_vol}</td>
       <td className={`px-4 py-1 text-right ${color}`}>
-        {percent > 0 ? `+${percent}` : `${percent}`}
+        {plusOrMinus}
+        {percentAbsolute}%
       </td>
       {/*<td className={'px-4 py-1 text-right'}>거래량 갯수</td>*/}
       <td className={'px-4 py-1 text-right'}>

--- a/FE/src/components/TopFive/Card.tsx
+++ b/FE/src/components/TopFive/Card.tsx
@@ -24,7 +24,9 @@ export default function Card({
     <div className='flex flex-row items-center justify-between py-3 hover:cursor-pointer'>
       <div className={'ml-2 font-medium text-juga-blue-50'}>{index + 1}</div>
       <div className='ml-4 w-[180px] text-start'>
-        <p className='font-medium text-juga-grayscale-black'>{name}</p>
+        <p className='overflow-hidden text-ellipsis whitespace-nowrap font-medium text-juga-grayscale-black'>
+          {name}
+        </p>
       </div>
       <div className='w-[120px] text-right'>
         <p className='font-normal text-juga-grayscale-black'>

--- a/FE/src/components/TopFive/TopFive.tsx
+++ b/FE/src/components/TopFive/TopFive.tsx
@@ -20,7 +20,7 @@ export default function TopFive() {
     queryFn: () => getTopFiveStocks(paramsMap[currentMarket]),
     keepPreviousData: true,
     cacheTime: 30000,
-    refetchInterval: 1000,
+    // refetchInterval: 1000,
   });
   return (
     <div className='flex flex-col gap-4'>

--- a/FE/src/utils/chart.ts
+++ b/FE/src/utils/chart.ts
@@ -56,7 +56,7 @@ export function drawBarChart(
     Math.min(...data.map((d) => +d.acml_vol)) * 1 - weight,
   );
 
-  const gap = Math.floor((width / n) * 0.8);
+  const gap = Math.floor(width / n);
 
   const blue = '#2175F3';
   const red = '#FF3700';
@@ -103,13 +103,13 @@ export function drawCandleChart(
     ctx.font = '20px Arial';
     ctx.fillStyle = '#000';
     ctx.textAlign = 'start';
-    ctx.fillText(label.toLocaleString(), padding.left + width + 10, yPos + 5);
+    ctx.fillText(label.toLocaleString(), padding.left + width + 80, yPos + 5);
 
     // Y축 눈금선 그리기
     ctx.strokeStyle = '#ddd';
     ctx.beginPath();
-    ctx.moveTo(0, yPos);
-    ctx.lineTo(padding.left + width, yPos);
+    ctx.moveTo(padding.left, yPos);
+    ctx.lineTo(padding.left + width + 56, yPos);
     ctx.stroke();
   });
 
@@ -117,7 +117,7 @@ export function drawCandleChart(
     ctx.beginPath();
 
     const { stck_oprc, stck_clpr, stck_hgpr, stck_lwpr } = e;
-    const gap = Math.floor((width / n) * 0.8);
+    const gap = Math.floor(width / n);
     const cx = x + padding.left + (width * i) / (n - 1);
 
     const openY =


### PR DESCRIPTION
두 가지 PR 템플릿 중 하나를 골라 작성하시면 됩니다!
### ✅ 주요 작업
- 등략률 0% 일 경우 색상을 검정색으로 표기
<img width="907" alt="스크린샷 2024-11-18 오후 5 55 51" src="https://github.com/user-attachments/assets/23c8f570-ba75-4e72-aba1-513a43af21cc">

- 시간 표기를 `hh:mm:ss`로 변경 & 모든 등락률을 소숫점 2번째자리까지 표현.
<img width="907" alt="스크린샷 2024-11-18 오후 5 56 04" src="https://github.com/user-attachments/assets/589f0870-417d-4df4-b864-616659afdaae">

- 주가지수 변경 사항에서 '+' 또는 '-'가 누락된 오류 수정.
<img width="1241" alt="스크린샷 2024-11-18 오후 5 56 21" src="https://github.com/user-attachments/assets/b0ef98db-ae21-4e64-bec0-57171d88e9c1">

- 띄어쓰기 포함시 하이라이트가 되지 않던 버그 수정 & 검색 기록에 띄어쓰기를 제거하여 저장하도록 수정.
<img width="638" alt="스크린샷 2024-11-18 오후 6 00 30" src="https://github.com/user-attachments/assets/0c98ef67-0660-419a-a609-14fdd480a76f">

### 💭 고민과 해결과정
- 고민과 해결과정

---
### 📊 FE/BE 전체 작업 내역
- #123 
