### PR TITLE
[BE] 25.02 소켓 재연결 로직 구현 #126

### DIFF
--- a/BE/src/websocket/base-socket.service.ts
+++ b/BE/src/websocket/base-socket.service.ts
@@ -63,6 +63,11 @@ export class BaseSocketService implements OnModuleInit {
 
     this.socket.onclose = () => {
       this.logger.warn(`한국투자증권 소켓 연결 종료`);
+      setTimeout(() => {
+        this.onModuleInit().catch((err) => {
+          throw new InternalServerErrorException(err);
+        });
+      }, 60000);
     };
   }
 


### PR DESCRIPTION
### ✅ 주요 작업
- [x] 소켓 재연결 로직 구현

### 💭 고민과 해결과정
- 한투 서버에서 ping을 보낼 시 pong을 보내는 로직을 구현하니 연결이 끊기는 문제는 줄어들었다고 생각했다. 그러나 11/15(금) 오후에 또 소켓 연결이 끊기는 문제가 발생했다....ㅠㅠ 그래서 핑퐁이 제대로 안되는줄 알았는데 또 연결해두니까 주말에는 연결이 지속되며 정상작동했다.
- 한투 Q&A를 찾아보니, 아래와 같이 금요일 프로세스 재기동시에 모든 소켓 연결이 끊기는 문제가 내부적으로 있다고 한다...
![image](https://github.com/user-attachments/assets/d2fec3e8-d31b-4407-9f74-4cfea4dfd727)
- 그래서 그냥 우리 서비스 로직 내에서 소켓 연결 끊기면 재연결 시켜주는 로직을 추가했다.
- 소켓에서 close 이벤트 발생 시 1분 간격 두고 onModuleInit 한번 더 실행시켜주도록 간단하게 해결했다.
- 아래와 같이 정상 작동한다.
![image](https://github.com/user-attachments/assets/0be84135-8c49-4fb4-a23c-ef0b64e320c3)

> 이제 잘 됐으면 좋겠다...... ...🥹