### PR TITLE
[FE] 그래프 고도화 작업(1) & SSE 연결 로직 구현

### DIFF
--- a/FE/src/components/StocksDetail/Chart.tsx
+++ b/FE/src/components/StocksDetail/Chart.tsx
@@ -17,7 +17,12 @@ type StocksDeatailChartProps = {
 
 export default function Chart({ code }: StocksDeatailChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const upperChartCanvasRef = useRef<HTMLCanvasElement>(null);
+  const lowerChartCanvasRef = useRef<HTMLCanvasElement>(null);
+  const upperChartY = useRef<HTMLCanvasElement>(null);
+  const lowerChartY = useRef<HTMLCanvasElement>(null);
+  const chartX = useRef<HTMLCanvasElement>(null);
+
   const [timeCategory, setTimeCategory] = useState<TiemCategory>('D');
 
   const { data, isLoading } = useQuery(
@@ -30,26 +35,42 @@ export default function Chart({ code }: StocksDeatailChartProps) {
     if (!data) return;
 
     const parent = containerRef.current;
-    const canvas = canvasRef.current;
+    const upperChartCanvas = upperChartCanvasRef.current;
+    const lowerChartCanvas = lowerChartCanvasRef.current;
+    const upperChartYCanvas = upperChartY.current;
+    const lowerChartYCanvas = lowerChartY.current;
 
-    if (!canvas || !parent) return;
+    if (!upperChartCanvas || !parent || !lowerChartCanvas) return;
 
     const displayWidth = parent.clientWidth;
     const displayHeight = parent.clientHeight;
 
     // 해상도 높이기
-    canvas.width = displayWidth * 2;
-    canvas.height = displayHeight * 2;
+    upperChartCanvas.width = displayWidth * 2;
+    upperChartCanvas.height = displayHeight * 2;
 
-    canvas.style.width = `${displayWidth}px`;
-    canvas.style.height = `${displayHeight * 0.8}px`;
+    upperChartCanvas.style.width = `${displayWidth}px`;
+    upperChartCanvas.style.height = `${displayHeight * 0.5}px`;
 
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    lowerChartCanvas.width = displayWidth * 2;
+    lowerChartCanvas.height = displayHeight * 2;
 
-    ctx.fillStyle = 'white';
+    lowerChartCanvas.style.width = `${displayWidth}px`;
+    lowerChartCanvas.style.height = `${displayHeight * 0.3}px`;
 
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    console.log(`${displayHeight * 0.8}px`);
+
+    const UpperChartCtx = upperChartCanvas.getContext('2d');
+    const LowerChartCtx = lowerChartCanvas.getContext('2d');
+
+    if (!UpperChartCtx || !LowerChartCtx) return;
+
+    // UpperChartCtx.fillRect(
+    //   0,
+    //   0,
+    //   upperChartCanvas.width,
+    //   upperChartCanvas.height,
+    // );
 
     const padding = {
       top: 20,
@@ -58,22 +79,44 @@ export default function Chart({ code }: StocksDeatailChartProps) {
       left: 20,
     };
 
-    const chartWidth = canvas.width - padding.left - padding.right;
-    const chartHeight = canvas.height - padding.top - padding.bottom;
-    const boundary = chartHeight * 0.8; // chartHeight의 80%
+    const chartWidth = upperChartCanvas.width - padding.left - padding.right;
+    const chartHeight = upperChartCanvas.height - padding.top - padding.bottom;
 
     const arr = data.map((e) => +e.stck_oprc);
 
-    drawLineChart(ctx, arr, 0, 0, chartWidth, boundary, padding, 0.1);
-    drawBarChart(ctx, data, 0, boundary, chartWidth, chartHeight, padding);
-    drawCandleChart(ctx, data, 0, 0, chartWidth, boundary, padding, 0.1);
+    drawLineChart(
+      UpperChartCtx,
+      arr,
+      0,
+      0,
+      chartWidth,
+      chartHeight,
+      padding,
+      0.1,
+    );
+    drawBarChart(
+      LowerChartCtx,
+      data,
+      0,
+      0, // chartHeight를 0으로 수정
+      lowerChartCanvas.width - padding.left - padding.right,
+      lowerChartCanvas.height - padding.top - padding.bottom,
+      padding,
+    );
+    drawCandleChart(
+      UpperChartCtx,
+      data,
+      0,
+      0,
+      chartWidth,
+      chartHeight,
+      padding,
+      0.1,
+    );
   }, [timeCategory, data, isLoading]);
 
   return (
-    <div
-      className='flex flex-1 flex-col items-center rounded-lg bg-juga-grayscale-50 p-3'
-      ref={containerRef}
-    >
+    <div className='flex h-[260px] flex-1 flex-col items-center rounded-lg bg-juga-grayscale-50 p-3'>
       <div className='flex w-full items-center justify-between'>
         <p className='font-semibold'>차트</p>
         <nav className='flex gap-4 text-sm'>
@@ -88,7 +131,22 @@ export default function Chart({ code }: StocksDeatailChartProps) {
           ))}
         </nav>
       </div>
-      <canvas ref={canvasRef} className='p-3' />
+      <div ref={containerRef} className={'mt-2 flex h-full w-full flex-col'}>
+        <div className={'flex h-full w-full flex-row items-center'}>
+          <canvas ref={upperChartCanvasRef} className='' />
+          <canvas ref={upperChartY} className={'w-[56px]'} />
+        </div>
+        {/*<div>*/}
+        {/*  <button> 실선</button>*/}
+        {/*</div>*/}
+        <div className={'flex w-full flex-row'}>
+          <canvas ref={lowerChartCanvasRef} className='' />
+          <canvas ref={lowerChartY} className={'w-[56px]'} />
+        </div>
+        <div className={'flex h-[32px] flex-row'}>
+          <canvas ref={chartX} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/FE/src/components/StocksDetail/Chart.tsx
+++ b/FE/src/components/StocksDetail/Chart.tsx
@@ -151,11 +151,9 @@ export default function Chart({ code }: StocksDeatailChartProps) {
 
     drawLowerYLabel(
       LowerYCtx,
-      data,
       lowerChartYCanvas.width - padding.left - padding.right,
       lowerChartYCanvas.height - padding.top - padding.bottom,
       padding,
-      0.1,
     );
   }, [timeCategory, data, isLoading]);
 

--- a/FE/src/components/StocksDetail/Chart.tsx
+++ b/FE/src/components/StocksDetail/Chart.tsx
@@ -4,7 +4,8 @@ import {
   drawBarChart,
   drawCandleChart,
   drawLineChart,
-  drawYLabel,
+  drawLowerYLabel,
+  drawUpperYLabel,
 } from 'utils/chart';
 import { useQuery } from '@tanstack/react-query';
 import { getStocksChartDataByCode } from 'service/stocks';
@@ -61,25 +62,22 @@ export default function Chart({ code }: StocksDeatailChartProps) {
     const chartWidth = displayWidth * 0.9;
     const yAxisWidth = displayWidth * 0.1;
 
-    // Upper 차트 영역 설정
+    // 차트 영역 설정
     upperChartCanvas.width = chartWidth * 2;
     upperChartCanvas.height = upperHeight * 2;
     upperChartCanvas.style.width = `${chartWidth}px`;
     upperChartCanvas.style.height = `${upperHeight}px`;
 
-    // Upper Y축 영역 설정
     upperChartYCanvas.width = yAxisWidth * 2;
     upperChartYCanvas.height = upperHeight * 2;
     upperChartYCanvas.style.width = `${yAxisWidth}px`;
     upperChartYCanvas.style.height = `${upperHeight}px`;
 
-    // Lower 차트 영역 설정 (Upper와 동일한 비율)
     lowerChartCanvas.width = chartWidth * 2;
     lowerChartCanvas.height = lowerHeight * 2;
     lowerChartCanvas.style.width = `${chartWidth}px`;
     lowerChartCanvas.style.height = `${lowerHeight}px`;
 
-    // Lower Y축 영역 설정
     lowerChartYCanvas.width = yAxisWidth * 2;
     lowerChartYCanvas.height = lowerHeight * 2;
     lowerChartYCanvas.style.width = `${yAxisWidth}px`;
@@ -109,7 +107,6 @@ export default function Chart({ code }: StocksDeatailChartProps) {
 
     const arr = data.map((e) => +e.stck_oprc);
 
-    // Upper 차트 그리기
     drawLineChart(
       UpperChartCtx,
       arr,
@@ -139,16 +136,24 @@ export default function Chart({ code }: StocksDeatailChartProps) {
       0,
       0,
       lowerChartWidth,
-      lowerChartHeight,
+      lowerChartHeight - padding.bottom,
       padding,
     );
 
-    // Upper Y축 라벨 그리기
-    drawYLabel(
+    drawUpperYLabel(
       UpperYCtx,
       data,
       upperChartYCanvas.width - padding.left - padding.right,
       upperChartYCanvas.height - padding.top - padding.bottom,
+      padding,
+      0.1,
+    );
+
+    drawLowerYLabel(
+      LowerYCtx,
+      data,
+      lowerChartYCanvas.width - padding.left - padding.right,
+      lowerChartYCanvas.height - padding.top - padding.bottom,
       padding,
       0.1,
     );

--- a/FE/src/components/StocksDetail/PriceSection.tsx
+++ b/FE/src/components/StocksDetail/PriceSection.tsx
@@ -3,10 +3,10 @@ import PriceTableColumn from './PriceTableColumn.tsx';
 import PriceTableLiveCard from './PriceTableLiveCard.tsx';
 import PriceTableDayCard from './PriceTableDayCard.tsx';
 import { useParams } from 'react-router-dom';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { DailyPriceDataType, PriceDataType } from './PriceDataType.ts';
 import { getTradeHistory } from 'service/getTradeHistory.ts';
-import { createSSEConnection } from './PriceSectionSseHook.ts';
+// import { createSSEConnection } from './PriceSectionSseHook.ts';
 
 export default function PriceSection() {
   const [buttonFlag, setButtonFlag] = useState(true);
@@ -35,10 +35,10 @@ export default function PriceSection() {
   // };
 
   // useEffect(() => {
-  //   if (!buttonFlag) return;
+  //   const targetWord = buttonFlag ? 'today' : 'daily';
   //
   //   const eventSource = createSSEConnection(
-  //     `http://223.130.151.42:3000/api/stocks/trade-history/${id}/today-sse`,
+  //     `http://223.130.151.42:3000/api/stocks/trade-history/${id}/${targetWord}-sse`,
   //     addData,
   //   );
   //

--- a/FE/src/components/StocksDetail/PriceSectionSseHook.ts
+++ b/FE/src/components/StocksDetail/PriceSectionSseHook.ts
@@ -1,0 +1,28 @@
+import { PriceDataType } from './PriceDataType.ts';
+
+export const createSSEConnection = (
+  url: string,
+  onMessage: (data: PriceDataType) => void,
+) => {
+  const eventSource = new EventSource(url);
+
+  eventSource.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      onMessage(data);
+    } catch (error) {
+      console.error('Failed to parse SSE message:', error);
+    }
+  };
+
+  eventSource.onerror = (error) => {
+    console.error('SSE Error:', error);
+    eventSource.close();
+  };
+
+  eventSource.onopen = () => {
+    console.log('SSE connection opened');
+  };
+
+  return eventSource;
+};

--- a/FE/src/utils/chart.ts
+++ b/FE/src/utils/chart.ts
@@ -42,19 +42,14 @@ export function drawBarChart(
   width: number,
   height: number,
   padding: Padding,
-  weight: number = 0, // 0~1 y축 범위 가중치
 ) {
   if (data.length === 0) return;
   const n = data.length;
 
   ctx.beginPath();
 
-  const yMax = Math.round(
-    Math.max(...data.map((d) => +d.acml_vol)) * 1 + weight,
-  );
-  const yMin = Math.round(
-    Math.min(...data.map((d) => +d.acml_vol)) * 1 - weight,
-  );
+  const yMax = Math.round(Math.max(...data.map((d) => +d.acml_vol)) * 1.2);
+  const yMin = Math.round(Math.min(...data.map((d) => +d.acml_vol)) * 0.8);
 
   const gap = Math.floor(width / n);
 
@@ -94,25 +89,6 @@ export function drawCandleChart(
   const yMax = Math.round(Math.max(...arr) * (1 + weight));
   const yMin = Math.round(Math.min(...arr) * (1 - weight));
 
-  const labels = getYAxisLabels(yMin, yMax);
-  labels.forEach((label) => {
-    const yPos =
-      padding.top + height - ((label - yMin) / (yMax - yMin)) * height;
-
-    // 라벨 텍스트 그리기
-    ctx.font = '20px Arial';
-    ctx.fillStyle = '#000';
-    ctx.textAlign = 'start';
-    ctx.fillText(label.toLocaleString(), padding.left + width + 80, yPos + 5);
-
-    // Y축 눈금선 그리기
-    ctx.strokeStyle = '#ddd';
-    ctx.beginPath();
-    ctx.moveTo(padding.left, yPos);
-    ctx.lineTo(padding.left + width + 56, yPos);
-    ctx.stroke();
-  });
-
   data.forEach((e, i) => {
     ctx.beginPath();
 
@@ -148,20 +124,6 @@ export function drawCandleChart(
     ctx.lineTo(middle, lowY);
     ctx.stroke();
   });
-}
-
-function getYAxisLabels(min: number, max: number) {
-  let a = min.toString().length - 1;
-  let k = 1;
-  while (a--) k *= 10;
-
-  const start = Math.ceil(min / k) * k;
-  const end = Math.floor(max / k) * k;
-  const labels = [];
-  for (let value = start; value <= end; value += k) {
-    labels.push(value);
-  }
-  return labels;
 }
 
 export const drawChart = (
@@ -249,4 +211,50 @@ export const drawChart = (
     ctx.lineWidth = 3;
     ctx.stroke();
   }
+};
+
+export const drawYLabel = (
+  ctx: CanvasRenderingContext2D,
+  data: StockChartUnit[],
+  width: number,
+  height: number,
+  padding: Padding,
+  weight: number = 0,
+) => {
+  const values = data
+    .map((d) => [+d.stck_hgpr, +d.stck_lwpr, +d.stck_clpr, +d.stck_oprc])
+    .flat();
+
+  const yMax = Math.round(Math.max(...values) * (1 + weight));
+  const yMin = Math.round(Math.min(...values) * (1 - weight));
+
+  ctx.clearRect(
+    0,
+    0,
+    width + padding.left + padding.right,
+    height + padding.top + padding.bottom,
+  );
+
+  // 라벨 갯수
+  const step = Math.ceil((yMax - yMin) / 3);
+  const labels = [];
+  for (let value = yMin; value <= yMax; value += step) {
+    labels.push(Math.round(value));
+  }
+  if (!labels.includes(yMax)) {
+    labels.push(yMax);
+  }
+
+  ctx.font = '24px sans-serif';
+  ctx.fillStyle = '#000';
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+
+  labels.forEach((label) => {
+    const yPos =
+      padding.top + height - ((label - yMin) / (yMax - yMin)) * height;
+
+    const formattedValue = label.toLocaleString();
+    ctx.fillText(formattedValue, width / 2, yPos);
+  });
 };

--- a/FE/src/utils/chart.ts
+++ b/FE/src/utils/chart.ts
@@ -280,11 +280,9 @@ export const drawUpperYLabel = (
 
 export const drawLowerYLabel = (
   ctx: CanvasRenderingContext2D,
-  data: StockChartUnit[],
   width: number,
   height: number,
   padding: Padding,
-  weight: number = 0,
 ) => {
   ctx.clearRect(
     0,

--- a/FE/src/utils/chart.ts
+++ b/FE/src/utils/chart.ts
@@ -46,7 +46,13 @@ export function drawBarChart(
   if (data.length === 0) return;
   const n = data.length;
 
-  ctx.beginPath();
+  // 캔버스 초기화
+  ctx.clearRect(
+    0,
+    0,
+    width + padding.left + padding.right,
+    height + padding.top + padding.bottom,
+  );
 
   const yMax = Math.round(Math.max(...data.map((d) => +d.acml_vol)) * 1.2);
   const yMin = Math.round(Math.min(...data.map((d) => +d.acml_vol)) * 0.8);
@@ -56,7 +62,15 @@ export function drawBarChart(
   const blue = '#2175F3';
   const red = '#FF3700';
 
+  ctx.beginPath();
+  ctx.moveTo(padding.left, height + 4);
+  ctx.lineTo(width + padding.left + padding.right, height + 4);
+  ctx.strokeStyle = '#D2DAE0';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
   data.forEach((e, i) => {
+    ctx.beginPath();
     const cx = x + padding.left + (width * i) / (n - 1);
     const cy =
       padding.top + ((height - y) * (+e.acml_vol - yMin)) / (yMax - yMin);
@@ -64,8 +78,6 @@ export function drawBarChart(
     ctx.fillStyle = +e.stck_oprc < +e.stck_clpr ? red : blue;
     ctx.fillRect(cx, height, gap, -cy);
   });
-
-  ctx.stroke();
 }
 
 export function drawCandleChart(
@@ -213,7 +225,7 @@ export const drawChart = (
   }
 };
 
-export const drawYLabel = (
+export const drawUpperYLabel = (
   ctx: CanvasRenderingContext2D,
   data: StockChartUnit[],
   width: number,
@@ -257,4 +269,41 @@ export const drawYLabel = (
     const formattedValue = label.toLocaleString();
     ctx.fillText(formattedValue, width / 2, yPos);
   });
+
+  ctx.beginPath();
+  ctx.moveTo(padding.left, 0);
+  ctx.lineTo(padding.left, height + padding.top + padding.bottom);
+  ctx.strokeStyle = '#D2DAE0';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+};
+
+export const drawLowerYLabel = (
+  ctx: CanvasRenderingContext2D,
+  data: StockChartUnit[],
+  width: number,
+  height: number,
+  padding: Padding,
+  weight: number = 0,
+) => {
+  ctx.clearRect(
+    0,
+    0,
+    width + padding.left + padding.right,
+    height + padding.top + padding.bottom,
+  );
+
+  // Y축 선 그리기
+  ctx.beginPath();
+  ctx.moveTo(padding.left, 0);
+  ctx.lineTo(padding.left, height + padding.top + 4);
+  ctx.strokeStyle = '#D2DAE0';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  // X축 선 그리기 (바닥 선)
+  ctx.beginPath();
+  ctx.moveTo(0, height + padding.top + 4);
+  ctx.lineTo(padding.left, height + padding.top + 4);
+  ctx.stroke();
 };


### PR DESCRIPTION
두 가지 PR 템플릿 중 하나를 골라 작성하시면 됩니다!
### ✅ 주요 작업
- 캔버스 분리
- 차트 분리
- 상단 차트 Y축 라벨 생성.
- X축, Y축 선 생성.
- SSE 연결 훅 생성.

https://github.com/user-attachments/assets/90277a0a-b946-47c0-8120-6afc40a0678f

### 💭 고민과 해결과정

#### 차트 고도화
 차트를 고도화하는 것은 어떤 기능을 추가하는 것인지 정리했을 때 추가로 필요한 기능은 다음과 같았다.
- 줌인, 줌 아웃.
- 좌우 드래그.
- 마우스 위치에 따른 X축 값, Y축 값 표시.

위의 기능들을 구현하기 위해 토즈 증권 사이트를 확인했다. 토스 증권 사이트의 경우 하나의 차트 내부에 총 5개의 켄버스가 있는 것을 확인할 수 있었다. 상단 차트, 하단 차트, X축, 상단 차트 Y축, 하단 차트 Y축 각각 따로따로 다른 켄버스였다. 그리고 캔버스를 외의 요소로 상단과 하단을 나누는 div 테그가 있었다. 다른 무엇보다 줌 인과 줌 아웃 기능을 구현하기 위해서는 하나의 켄버스에 전체를 그리는 것보다 여러개의 켄버스를 감싼 하나의 테그를 이용해 이벤트처리로 데이터를 바꿔주는 과정이 필요하다고 생각했다.
따라서 우선 하나의 켄버스를 5개의 켄버스로 나누는 과정부터 진행했다. 나누는 과정에서 불필요한 코드를 제거하고 전체 화면 비율이 맞지 않았기 때문에 화면 비율을 위해 추가로 변수들을 선언했다.

---
### 📊 FE/BE 전체 작업 내역
- #61 
- #123 
