### PR TITLE
[FE] 매수 API 연동 & 거래 확인 모달 레이아웃 구현

### DIFF
--- a/FE/src/components/StocksDetail/TradeAlertModal.tsx
+++ b/FE/src/components/StocksDetail/TradeAlertModal.tsx
@@ -1,0 +1,73 @@
+import Overay from 'components/ModalOveray';
+import { buyStock } from 'service/stocks';
+import useAuthStore from 'store/authStore';
+import useTradeAlertModalStore from 'store/tradeAlertModalStore';
+
+type TradeAlertModalProps = {
+  code: string;
+  stockName: string;
+  price: string;
+  count: number;
+};
+
+export default function TradeAlertModal({
+  code,
+  stockName,
+  price,
+  count,
+}: TradeAlertModalProps) {
+  const { toggleModal } = useTradeAlertModalStore();
+  const { accessToken } = useAuthStore();
+
+  if (!accessToken) {
+    console.log('accessToken 없음!');
+    return;
+  }
+
+  const charge = 55; // 수수료 임시
+
+  const handleBuy = async () => {
+    const res = await buyStock(code, +price, count, accessToken);
+    if (res.ok) toggleModal();
+  };
+
+  return (
+    <>
+      <Overay onClick={() => toggleModal()} />
+      <section className='fixed left-1/2 top-1/2 flex w-[500px] -translate-x-1/2 -translate-y-1/2 flex-col rounded-2xl bg-white p-5 shadow-lg'>
+        <div className='self-start text-lg font-bold'>
+          {stockName} 매수 {count}주
+        </div>
+        <div className='flex flex-col gap-2 my-5 text-juga-grayscale-500'>
+          <div className='flex justify-between'>
+            <p>{count}주 희망가격</p>
+            <p>{(+price).toLocaleString()}원</p>
+          </div>
+          <div className='flex justify-between'>
+            <p>예상 수수료</p>
+            <p>{charge}원</p>
+          </div>{' '}
+          <div className='flex justify-between'>
+            <p>총 주문 금액</p>
+            <p>{(+price + charge).toLocaleString()}원</p>
+          </div>
+        </div>
+
+        <div className='flex justify-end gap-2'>
+          <button
+            className='px-6 py-2 text-gray-800 rounded-xl bg-juga-grayscale-100'
+            onClick={toggleModal}
+          >
+            취소
+          </button>
+          <button
+            className='px-6 py-2 text-white rounded-xl bg-juga-red-60'
+            onClick={handleBuy}
+          >
+            구매
+          </button>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/FE/src/components/StocksDetail/TradeSection.tsx
+++ b/FE/src/components/StocksDetail/TradeSection.tsx
@@ -1,14 +1,25 @@
 import Lottie from 'lottie-react';
-import { ChangeEvent, FocusEvent, useEffect, useRef, useState } from 'react';
+import {
+  ChangeEvent,
+  FocusEvent,
+  FormEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import emptyAnimation from 'assets/emptyAnimation.json';
+import { buyStock } from 'service/stocks';
+import useAuthStore from 'store/authStore';
 
 type TradeSectionProps = {
+  code: string;
   price: string;
 };
 
-export default function TradeSection({ price }: TradeSectionProps) {
+export default function TradeSection({ code, price }: TradeSectionProps) {
   const upperLimit = Math.floor(+price * 1.3);
   const lowerLimit = Math.floor(+price * 0.7);
+  const { accessToken } = useAuthStore();
 
   const [category, setCategory] = useState<'buy' | 'sell'>('buy');
   const [currPrice, setCurrPrice] = useState<string>(price);
@@ -67,6 +78,16 @@ export default function TradeSection({ price }: TradeSectionProps) {
     }
   };
 
+  const handleBuy = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!accessToken) {
+      console.log('accessToken 없음!');
+      return;
+    }
+    const res = await buyStock(code, +currPrice, count, accessToken);
+    console.log(res);
+  };
+
   return (
     <section className='flex flex-col w-full p-4 ml-2 text-sm rounded-lg min-w-72 bg-juga-grayscale-50'>
       <h2 className='self-start mb-4 font-semibold'>주문하기</h2>
@@ -98,7 +119,7 @@ export default function TradeSection({ price }: TradeSectionProps) {
         </button>
       </div>
       {category === 'buy' ? (
-        <form className='flex flex-col'>
+        <form className='flex flex-col' onSubmit={handleBuy}>
           <div className='my-4'>
             <div className='flex items-center justify-between h-12'>
               <p className='mr-3 w-14'>매수 가격</p>

--- a/FE/src/components/StocksDetail/TradeSection.tsx
+++ b/FE/src/components/StocksDetail/TradeSection.tsx
@@ -10,21 +10,22 @@ import {
 import emptyAnimation from 'assets/emptyAnimation.json';
 import { buyStock } from 'service/stocks';
 import useAuthStore from 'store/authStore';
+import { StockDetailType } from 'types';
 
 type TradeSectionProps = {
   code: string;
-  price: string;
+  data: StockDetailType;
 };
 
 const MyAsset = 10000000;
 
-export default function TradeSection({ code, price }: TradeSectionProps) {
-  const upperLimit = Math.floor(+price * 1.3);
-  const lowerLimit = Math.floor(+price * 0.7);
+export default function TradeSection({ code, data }: TradeSectionProps) {
+  const { stck_prpr, stck_mxpr, stck_llam } = data;
+
   const { accessToken } = useAuthStore();
 
   const [category, setCategory] = useState<'buy' | 'sell'>('buy');
-  const [currPrice, setCurrPrice] = useState<string>(price);
+  const [currPrice, setCurrPrice] = useState<string>(stck_prpr);
   const [upperLimitFlag, setUpperLimitFlag] = useState<boolean>(false);
   const [lowerLimitFlag, setLowerLimitFlag] = useState<boolean>(false);
   const [lackAssetFlag, setLackAssetFlag] = useState<boolean>(false);
@@ -54,11 +55,11 @@ export default function TradeSection({ code, price }: TradeSectionProps) {
 
   const handlePriceInputBlur = (e: FocusEvent<HTMLInputElement>) => {
     const n = +e.target.value;
-    if (n > upperLimit) {
+    if (n > +stck_mxpr) {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
-      setCurrPrice(upperLimit.toString());
+      setCurrPrice(stck_mxpr);
 
       setUpperLimitFlag(true);
       timerRef.current = setTimeout(() => {
@@ -67,11 +68,11 @@ export default function TradeSection({ code, price }: TradeSectionProps) {
       return;
     }
 
-    if (n < lowerLimit) {
+    if (n < +stck_llam) {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
-      setCurrPrice(lowerLimit.toString());
+      setCurrPrice(stck_llam);
 
       setLowerLimitFlag(true);
       timerRef.current = setTimeout(() => {
@@ -147,12 +148,12 @@ export default function TradeSection({ code, price }: TradeSectionProps) {
             </div>
             {lowerLimitFlag && (
               <div className='text-sm text-juga-red-60'>
-                이 주식의 최소 가격은 {lowerLimit.toLocaleString()}입니다.
+                이 주식의 최소 가격은 {(+stck_llam).toLocaleString()}입니다.
               </div>
             )}
             {upperLimitFlag && (
               <div className='text-xs text-juga-red-60'>
-                이 주식의 최대 가격은 {upperLimit.toLocaleString()}입니다.
+                이 주식의 최대 가격은 {(+stck_mxpr).toLocaleString()}입니다.
               </div>
             )}
             <div className='flex items-center justify-between h-12'>

--- a/FE/src/components/StocksDetail/TradeSection.tsx
+++ b/FE/src/components/StocksDetail/TradeSection.tsx
@@ -8,9 +8,10 @@ import {
   useState,
 } from 'react';
 import emptyAnimation from 'assets/emptyAnimation.json';
-import { buyStock } from 'service/stocks';
-import useAuthStore from 'store/authStore';
 import { StockDetailType } from 'types';
+import useTradeAlertModalStore from 'store/tradeAlertModalStore';
+import TradeAlertModal from './TradeAlertModal';
+import useAuthStore from 'store/authStore';
 
 type TradeSectionProps = {
   code: string;
@@ -22,13 +23,13 @@ const MyAsset = 10000000;
 export default function TradeSection({ code, data }: TradeSectionProps) {
   const { stck_prpr, stck_mxpr, stck_llam } = data;
 
-  const { accessToken } = useAuthStore();
-
   const [category, setCategory] = useState<'buy' | 'sell'>('buy');
   const [currPrice, setCurrPrice] = useState<string>(stck_prpr);
   const [upperLimitFlag, setUpperLimitFlag] = useState<boolean>(false);
   const [lowerLimitFlag, setLowerLimitFlag] = useState<boolean>(false);
   const [lackAssetFlag, setLackAssetFlag] = useState<boolean>(false);
+  const { isOpen, toggleModal } = useTradeAlertModalStore();
+  const { accessToken } = useAuthStore();
 
   const [count, setCount] = useState<number>(0);
 
@@ -98,108 +99,119 @@ export default function TradeSection({ code, data }: TradeSectionProps) {
       }, 2000);
       return;
     }
-
-    const res = await buyStock(code, +currPrice, count, accessToken);
-    console.log(res);
+    toggleModal();
   };
 
   return (
-    <section className='flex flex-col w-full p-4 ml-2 text-sm rounded-lg min-w-72 bg-juga-grayscale-50'>
-      <h2 className='self-start mb-4 font-semibold'>주문하기</h2>
-      <div className='relative flex w-full rounded-xl bg-gray-200 p-0.5'>
-        <div
-          ref={indicatorRef}
-          className='absolute bottom-0.5 rounded-xl bg-white shadow transition-all duration-300'
-          style={{ height: '28px' }}
-        />
-        <button
-          className={`z-7 relative w-full rounded-lg px-4 py-1 ${
-            category === 'buy' ? 'text-juga-red-60' : 'text-juga-grayscale-400'
-          }`}
-          onClick={() => setCategory('buy')}
-          ref={(el) => (buttonRefs.current[0] = el)}
-        >
-          매수
-        </button>
-        <button
-          className={`z-7 relative w-full rounded-lg ${
-            category === 'sell'
-              ? 'text-juga-blue-50'
-              : 'text-juga-grayscale-400'
-          } z-7 relative w-full rounded-lg px-4 py-1`}
-          onClick={() => setCategory('sell')}
-          ref={(el) => (buttonRefs.current[1] = el)}
-        >
-          매도
-        </button>
-      </div>
-      {category === 'buy' ? (
-        <form className='flex flex-col' onSubmit={handleBuy}>
-          <div className='my-4'>
-            <div className='flex items-center justify-between h-12'>
-              <p className='mr-3 w-14'>매수 가격</p>
-              <input
-                type='text'
-                value={currPrice}
-                onChange={handlePriceChange}
-                onBlur={handlePriceInputBlur}
-                className='flex-1 py-1 rounded-lg'
-              />
-            </div>
-            {lowerLimitFlag && (
-              <div className='text-sm text-juga-red-60'>
-                이 주식의 최소 가격은 {(+stck_llam).toLocaleString()}입니다.
-              </div>
-            )}
-            {upperLimitFlag && (
-              <div className='text-xs text-juga-red-60'>
-                이 주식의 최대 가격은 {(+stck_mxpr).toLocaleString()}입니다.
-              </div>
-            )}
-            <div className='flex items-center justify-between h-12'>
-              <p className='mr-3 w-14'> 수량</p>
-              <input
-                type='number'
-                value={count}
-                onChange={(e) => setCount(+e.target.value)}
-                className='flex-1 py-1 rounded-lg'
-              />
-            </div>
-          </div>
-
-          <div className='my-5 h-[0.5px] w-full bg-juga-grayscale-200'></div>
-
-          <div className='flex flex-col gap-2'>
-            <div className='flex justify-between'>
-              <p>매수 가능 금액</p>
-              <p>0원</p>
-            </div>
-            <div className='flex justify-between'>
-              <p>총 주문 금액</p>
-              <p>{(+currPrice * count).toLocaleString()}원</p>
-            </div>
-          </div>
-
-          <div className='flex flex-col justify-center h-10'>
-            {lackAssetFlag && (
-              <p className='text-xs text-juga-red-60'>잔액이 부족해요!</p>
-            )}
-          </div>
-          <button className='py-2 text-white rounded-lg bg-juga-red-60'>
-            매수하기
-          </button>
-        </form>
-      ) : (
-        <div className='flex flex-col items-center justify-center h-full'>
-          <Lottie
-            animationData={emptyAnimation}
-            className='w-40 h-40'
-            loop={false}
+    <>
+      <section className='flex flex-col w-full p-4 ml-2 text-sm rounded-lg min-w-72 bg-juga-grayscale-50'>
+        <h2 className='self-start mb-4 font-semibold'>주문하기</h2>
+        <div className='relative flex w-full rounded-xl bg-gray-200 p-0.5'>
+          <div
+            ref={indicatorRef}
+            className='absolute bottom-0.5 rounded-xl bg-white shadow transition-all duration-300'
+            style={{ height: '28px' }}
           />
-          <p>매도할 주식이 없어요</p>
+          <button
+            className={`z-7 relative w-full rounded-lg px-4 py-1 ${
+              category === 'buy'
+                ? 'text-juga-red-60'
+                : 'text-juga-grayscale-400'
+            }`}
+            onClick={() => setCategory('buy')}
+            ref={(el) => (buttonRefs.current[0] = el)}
+          >
+            매수
+          </button>
+          <button
+            className={`z-7 relative w-full rounded-lg ${
+              category === 'sell'
+                ? 'text-juga-blue-50'
+                : 'text-juga-grayscale-400'
+            } z-7 relative w-full rounded-lg px-4 py-1`}
+            onClick={() => setCategory('sell')}
+            ref={(el) => (buttonRefs.current[1] = el)}
+          >
+            매도
+          </button>
         </div>
+        {category === 'buy' ? (
+          <form className='flex flex-col' onSubmit={handleBuy}>
+            <div className='my-4'>
+              <div className='flex items-center justify-between h-12'>
+                <p className='mr-3 w-14'>매수 가격</p>
+                <input
+                  type='text'
+                  value={currPrice}
+                  onChange={handlePriceChange}
+                  onBlur={handlePriceInputBlur}
+                  className='flex-1 py-1 rounded-lg'
+                />
+              </div>
+              {lowerLimitFlag && (
+                <div className='text-sm text-juga-red-60'>
+                  이 주식의 최소 가격은 {(+stck_llam).toLocaleString()}입니다.
+                </div>
+              )}
+              {upperLimitFlag && (
+                <div className='text-xs text-juga-red-60'>
+                  이 주식의 최대 가격은 {(+stck_mxpr).toLocaleString()}입니다.
+                </div>
+              )}
+              <div className='flex items-center justify-between h-12'>
+                <p className='mr-3 w-14'> 수량</p>
+                <input
+                  type='number'
+                  value={count}
+                  onChange={(e) => setCount(+e.target.value)}
+                  className='flex-1 py-1 rounded-lg'
+                  min={1}
+                />
+              </div>
+            </div>
+
+            <div className='my-5 h-[0.5px] w-full bg-juga-grayscale-200'></div>
+
+            <div className='flex flex-col gap-2'>
+              <div className='flex justify-between'>
+                <p>매수 가능 금액</p>
+                <p>0원</p>
+              </div>
+              <div className='flex justify-between'>
+                <p>총 주문 금액</p>
+                <p>{(+currPrice * count).toLocaleString()}원</p>
+              </div>
+            </div>
+
+            <div className='flex flex-col justify-center h-10'>
+              {lackAssetFlag && (
+                <p className='text-xs text-juga-red-60'>잔액이 부족해요!</p>
+              )}
+            </div>
+            <button className='py-2 text-white rounded-lg bg-juga-red-60'>
+              매수하기
+            </button>
+          </form>
+        ) : (
+          <div className='flex flex-col items-center justify-center h-full'>
+            <Lottie
+              animationData={emptyAnimation}
+              className='w-40 h-40'
+              loop={false}
+            />
+            <p>매도할 주식이 없어요</p>
+          </div>
+        )}
+      </section>
+      {isOpen && (
+        <TradeAlertModal
+          code={code}
+          stockName={data.hts_kor_isnm}
+          price={currPrice}
+          count={count}
+        />
       )}
-    </section>
+    </>
   );
 }
 

--- a/FE/src/components/StocksDetail/TradeSection.tsx
+++ b/FE/src/components/StocksDetail/TradeSection.tsx
@@ -16,6 +16,8 @@ type TradeSectionProps = {
   price: string;
 };
 
+const MyAsset = 10000000;
+
 export default function TradeSection({ code, price }: TradeSectionProps) {
   const upperLimit = Math.floor(+price * 1.3);
   const lowerLimit = Math.floor(+price * 0.7);
@@ -25,6 +27,7 @@ export default function TradeSection({ code, price }: TradeSectionProps) {
   const [currPrice, setCurrPrice] = useState<string>(price);
   const [upperLimitFlag, setUpperLimitFlag] = useState<boolean>(false);
   const [lowerLimitFlag, setLowerLimitFlag] = useState<boolean>(false);
+  const [lackAssetFlag, setLackAssetFlag] = useState<boolean>(false);
 
   const [count, setCount] = useState<number>(0);
 
@@ -84,6 +87,17 @@ export default function TradeSection({ code, price }: TradeSectionProps) {
       console.log('accessToken 없음!');
       return;
     }
+
+    const price = +currPrice * count;
+
+    if (price > MyAsset) {
+      setLackAssetFlag(true);
+      timerRef.current = setTimeout(() => {
+        setLackAssetFlag(false);
+      }, 2000);
+      return;
+    }
+
     const res = await buyStock(code, +currPrice, count, accessToken);
     console.log(res);
   };
@@ -165,7 +179,12 @@ export default function TradeSection({ code, price }: TradeSectionProps) {
             </div>
           </div>
 
-          <button className='py-2 mt-10 text-white rounded-lg bg-juga-red-60'>
+          <div className='flex flex-col justify-center h-10'>
+            {lackAssetFlag && (
+              <p className='text-xs text-juga-red-60'>잔액이 부족해요!</p>
+            )}
+          </div>
+          <button className='py-2 text-white rounded-lg bg-juga-red-60'>
             매수하기
           </button>
         </form>

--- a/FE/src/page/StocksDetail.tsx
+++ b/FE/src/page/StocksDetail.tsx
@@ -20,8 +20,6 @@ export default function StocksDetail() {
   if (isLoading) return <div>Loading...</div>;
   if (!data) return <div>Non data</div>;
 
-  const { stck_prpr } = data;
-
   return (
     <div className='flex flex-col'>
       <Header code={code} data={data} />
@@ -30,7 +28,7 @@ export default function StocksDetail() {
           <Chart code={code} />
           <PriceSection />
         </div>
-        <TradeSection code={code} price={stck_prpr} />
+        <TradeSection code={code} data={data} />
       </div>
     </div>
   );

--- a/FE/src/page/StocksDetail.tsx
+++ b/FE/src/page/StocksDetail.tsx
@@ -30,7 +30,7 @@ export default function StocksDetail() {
           <Chart code={code} />
           <PriceSection />
         </div>
-        <TradeSection price={stck_prpr} />
+        <TradeSection code={code} price={stck_prpr} />
       </div>
     </div>
   );

--- a/FE/src/service/stocks.ts
+++ b/FE/src/service/stocks.ts
@@ -22,3 +22,23 @@ export async function getStocksChartDataByCode(
     }),
   }).then((res) => res.json());
 }
+
+export async function buyStock(
+  code: string,
+  price: number,
+  amount: number,
+  token: string,
+) {
+  return fetch(`${import.meta.env.VITE_API_URL}/stocks/trade/buy`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      stock_code: code,
+      price,
+      amount,
+    }),
+  });
+}

--- a/FE/src/store/tradeAlertModalStore.ts
+++ b/FE/src/store/tradeAlertModalStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+type ModalStore = {
+  isOpen: boolean;
+  toggleModal: () => void;
+};
+
+const useTradeAlertModalStore = create<ModalStore>((set) => ({
+  isOpen: false,
+  toggleModal: () => set((state) => ({ isOpen: !state.isOpen })),
+}));
+
+export default useTradeAlertModalStore;

--- a/FE/src/types.ts
+++ b/FE/src/types.ts
@@ -26,6 +26,8 @@ export type StockDetailType = {
   prdy_ctrt: string;
   hts_avls: string;
   per: string;
+  stck_mxpr: string;
+  stck_llam: string;
 };
 
 export type StockChartUnit = {


### PR DESCRIPTION
### ✅ 주요 작업
- 매수 API 연동
- 거래 확인 모달 레이아웃
- 서버에서 주식 상한가, 하한가 정보 받아와서 주식 가격 범위 제한

<img width="1305" alt="image" src="https://github.com/user-attachments/assets/2c5abb79-aff3-49e8-aafc-bdd4ea8ed6e7">


close #136