### PR TITLE
[BE] 8.05, 8.07 프로필 및 포트폴리오 API 구현 #150

### DIFF
--- a/BE/src/asset/asset.controller.ts
+++ b/BE/src/asset/asset.controller.ts
@@ -8,6 +8,7 @@ import {
 import { Request } from 'express';
 import { JwtAuthGuard } from '../auth/jwt-auth-guard';
 import { AssetService } from './asset.service';
+import { MypageResponseDto } from './dto/mypage-response.dto';
 
 @Controller('/api/assets')
 @ApiTags('사용자 자산 및 보유 주식 API')
@@ -49,5 +50,21 @@ export class AssetController {
   })
   async getCashBalance(@Req() request: Request) {
     return this.assetService.getCashBalance(parseInt(request.user.userId, 10));
+  }
+
+  @Get()
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: '마이페이지 보유 자산 현황 조회 API',
+    description: '마이페이지 조회 시 필요한 보유 자산 현황을 조회한다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '매수 가능 금액 조회 성공',
+    type: MypageResponseDto,
+  })
+  async getMyPage(@Req() request: Request) {
+    return this.assetService.getMyPage(parseInt(request.user.userId, 10));
   }
 }

--- a/BE/src/asset/asset.controller.ts
+++ b/BE/src/asset/asset.controller.ts
@@ -69,7 +69,7 @@ export class AssetController {
     return this.assetService.getMyPage(parseInt(request.user.userId, 10));
   }
 
-  @Cron('*/1 9-16 * * 1-5')
+  @Cron('*/10 9-16 * * 1-5')
   async updateStockBalance() {
     await this.assetService.updateStockBalance();
   }

--- a/BE/src/asset/asset.controller.ts
+++ b/BE/src/asset/asset.controller.ts
@@ -6,6 +6,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Request } from 'express';
+import { Cron } from '@nestjs/schedule';
 import { JwtAuthGuard } from '../auth/jwt-auth-guard';
 import { AssetService } from './asset.service';
 import { MypageResponseDto } from './dto/mypage-response.dto';
@@ -66,5 +67,10 @@ export class AssetController {
   })
   async getMyPage(@Req() request: Request) {
     return this.assetService.getMyPage(parseInt(request.user.userId, 10));
+  }
+
+  @Cron('*/1 9-16 * * 1-5')
+  async updateStockBalance() {
+    await this.assetService.updateStockBalance();
   }
 }

--- a/BE/src/asset/asset.module.ts
+++ b/BE/src/asset/asset.module.ts
@@ -6,9 +6,10 @@ import { AssetRepository } from './asset.repository';
 import { Asset } from './asset.entity';
 import { UserStock } from './user-stock.entity';
 import { UserStockRepository } from './user-stock.repository';
+import { StockDetailModule } from '../stock/detail/stock-detail.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Asset, UserStock])],
+  imports: [TypeOrmModule.forFeature([Asset, UserStock]), StockDetailModule],
   controllers: [AssetController],
   providers: [AssetService, AssetRepository, UserStockRepository],
   exports: [AssetRepository, UserStockRepository],

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { UserStockRepository } from './user-stock.repository';
 import { AssetRepository } from './asset.repository';
+import { MypageResponseDto } from './dto/mypage-response.dto';
+import { StockElementResponseDto } from './dto/stock-element-response.dto';
+import { AssetResponseDto } from './dto/asset-response.dto';
 
 @Injectable()
 export class AssetService {
@@ -22,5 +25,34 @@ export class AssetService {
     const asset = await this.assetRepository.findOneBy({ user_id: userId });
 
     return { cash_balance: asset.cash_balance };
+  }
+
+  async getMyPage(userId: number) {
+    const userStocks =
+      await this.userStockRepository.findUserStockWithNameByUserId(userId);
+    const asset = await this.assetRepository.findOneBy({ user_id: userId });
+
+    const myStocks = userStocks.map((userStock) => {
+      return new StockElementResponseDto(
+        userStock.stocks_name,
+        userStock.stocks_code,
+        userStock.user_stocks_quantity,
+        userStock.user_stocks_avg_price,
+      );
+    });
+
+    const myAsset = new AssetResponseDto(
+      asset.cash_balance,
+      asset.stock_balance,
+      asset.total_asset,
+      asset.total_profit,
+      asset.total_profit_rate,
+    );
+
+    const response = new MypageResponseDto();
+    response.asset = myAsset;
+    response.stocks = myStocks;
+
+    return response;
   }
 }

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -79,6 +79,7 @@ export class AssetService {
         await this.assetRepository.update(asset.id, {
           stock_balance: totalPrice,
           total_asset: asset.cash_balance + totalPrice,
+          last_updated: new Date(),
         });
       }),
     );

--- a/BE/src/asset/dto/asset-response.dto.ts
+++ b/BE/src/asset/dto/asset-response.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AssetResponseDto {
+  constructor(
+    cash_balance,
+    stock_balance,
+    total_asset,
+    total_profit,
+    total_profit_rate,
+  ) {
+    this.cash_balance = cash_balance;
+    this.stock_balance = stock_balance;
+    this.total_asset = total_asset;
+    this.total_profit = total_profit;
+    this.total_profit_rate = total_profit_rate;
+  }
+
+  @ApiProperty({ description: '보유 현금' })
+  cash_balance: number;
+
+  @ApiProperty({ description: '주식 평가 금액' })
+  stock_balance: number;
+
+  @ApiProperty({ description: '총 자산' })
+  total_asset: number;
+
+  @ApiProperty({ description: '총 수익금' })
+  total_profit: number;
+
+  @ApiProperty({ description: '총 수익률' })
+  total_profit_rate: number;
+}

--- a/BE/src/asset/dto/mypage-response.dto.ts
+++ b/BE/src/asset/dto/mypage-response.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { StockElementResponseDto } from './stock-element-response.dto';
+import { AssetResponseDto } from './asset-response.dto';
+
+export class MypageResponseDto {
+  @ApiProperty({
+    description: '보유 자산',
+    type: AssetResponseDto,
+  })
+  asset: AssetResponseDto;
+
+  @ApiProperty({
+    description: '보유 주식 리스트',
+    type: [StockElementResponseDto],
+  })
+  stocks: StockElementResponseDto[];
+}

--- a/BE/src/asset/dto/stock-element-response.dto.ts
+++ b/BE/src/asset/dto/stock-element-response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StockElementResponseDto {
+  constructor(name, code, quantity, avg_price) {
+    this.name = name;
+    this.code = code;
+    this.quantity = quantity;
+    this.avg_price = avg_price;
+  }
+
+  @ApiProperty({ description: '종목 이름' })
+  name: string;
+
+  @ApiProperty({ description: '종목 코드' })
+  code: string;
+
+  @ApiProperty({ description: '보유량' })
+  quantity: number;
+
+  @ApiProperty({ description: '평균 매수가' })
+  avg_price: number;
+}

--- a/BE/src/asset/interface/user-stock.interface.ts
+++ b/BE/src/asset/interface/user-stock.interface.ts
@@ -1,0 +1,11 @@
+export interface UserStockInterface {
+  user_stocks_id: number;
+  user_stocks_user_id: number;
+  user_stocks_stock_code: string;
+  user_stocks_quantity: number;
+  user_stocks_avg_price: string;
+  user_stocks_last_updated: Date;
+  stocks_code: string;
+  stocks_name: string;
+  stocks_market: string;
+}

--- a/BE/src/asset/user-stock.repository.ts
+++ b/BE/src/asset/user-stock.repository.ts
@@ -2,10 +2,22 @@ import { Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { UserStock } from './user-stock.entity';
+import { UserStockInterface } from './interface/user-stock.interface';
 
 @Injectable()
 export class UserStockRepository extends Repository<UserStock> {
   constructor(@InjectDataSource() private dataSource: DataSource) {
     super(UserStock, dataSource.createEntityManager());
+  }
+
+  findUserStockWithNameByUserId(userId: number) {
+    return this.createQueryBuilder('user_stocks')
+      .leftJoinAndSelect(
+        'stocks',
+        'stocks',
+        'stocks.code = user_stocks.stock_code',
+      )
+      .where('user_stocks.user_id = :userId', { userId })
+      .getRawMany<UserStockInterface>();
   }
 }

--- a/BE/src/asset/user-stock.repository.ts
+++ b/BE/src/asset/user-stock.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, MoreThan, Repository } from 'typeorm';
 import { UserStock } from './user-stock.entity';
 import { UserStockInterface } from './interface/user-stock.interface';
 
@@ -19,5 +19,12 @@ export class UserStockRepository extends Repository<UserStock> {
       )
       .where('user_stocks.user_id = :userId', { userId })
       .getRawMany<UserStockInterface>();
+  }
+
+  findAllDistinctCode() {
+    return this.createQueryBuilder('user_stocks')
+      .select('DISTINCT user_stocks.stock_code')
+      .where({ quantity: MoreThan(0) })
+      .getRawMany();
   }
 }

--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -10,6 +10,8 @@ import { UserRepository } from './user.repository';
 import { JwtStrategy } from './strategy/jwt.strategy';
 import { KakaoStrategy } from './strategy/kakao.strategy';
 import { AssetModule } from '../asset/asset.module';
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
 
 @Module({
   imports: [
@@ -28,8 +30,14 @@ import { AssetModule } from '../asset/asset.module';
     }),
     AssetModule,
   ],
-  controllers: [AuthController],
-  providers: [AuthService, UserRepository, JwtStrategy, KakaoStrategy],
+  controllers: [AuthController, UserController],
+  providers: [
+    AuthService,
+    UserRepository,
+    JwtStrategy,
+    KakaoStrategy,
+    UserService,
+  ],
   exports: [JwtStrategy, PassportModule],
 })
 export class AuthModule {}

--- a/BE/src/auth/dto/profile-response.dto.ts
+++ b/BE/src/auth/dto/profile-response.dto.ts
@@ -1,0 +1,9 @@
+export class ProfileResponseDto {
+  constructor(name, email) {
+    this.name = name;
+    this.email = email;
+  }
+
+  name: string;
+  email: string;
+}

--- a/BE/src/auth/user.controller.ts
+++ b/BE/src/auth/user.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Request } from 'express';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { UserService } from './user.service';
+import { JwtAuthGuard } from './jwt-auth-guard';
+import { ProfileResponseDto } from './dto/profile-response.dto';
+
+@Controller('/api/user')
+@ApiTags('프로필 API')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  @Get('/profile')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '내 프로필 조회 API' })
+  @ApiResponse({
+    status: 200,
+    description: '프로필 조회 성공',
+    type: ProfileResponseDto,
+  })
+  getProfile(@Req() request: Request) {
+    return this.userService.getProfile(parseInt(request.user.userId, 10));
+  }
+}

--- a/BE/src/auth/user.entity.ts
+++ b/BE/src/auth/user.entity.ts
@@ -7,6 +7,9 @@ export class User extends BaseEntity {
   id: number;
 
   @Column()
+  name: string;
+
+  @Column()
   email: string;
 
   @Column()

--- a/BE/src/auth/user.service.ts
+++ b/BE/src/auth/user.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { UserRepository } from './user.repository';
+import { ProfileResponseDto } from './dto/profile-response.dto';
+
+@Injectable()
+export class UserService {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async getProfile(userId: number) {
+    const user = await this.userRepository.findOneBy({ id: userId });
+    return new ProfileResponseDto(user.name, user.email);
+  }
+}

--- a/BE/src/stock/detail/stock-detail.module.ts
+++ b/BE/src/stock/detail/stock-detail.module.ts
@@ -10,5 +10,6 @@ import { Stocks } from './stock-detail.entity';
   imports: [KoreaInvestmentModule, TypeOrmModule.forFeature([Stocks])],
   controllers: [StockDetailController],
   providers: [StockDetailService, StockDetailRepository],
+  exports: [StockDetailService],
 })
 export class StockDetailModule {}

--- a/BE/src/stock/order/dto/stock-order-element-response.dto.ts
+++ b/BE/src/stock/order/dto/stock-order-element-response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { TradeType } from '../enum/trade-type';
+
+export class StockOrderElementResponseDto {
+  constructor(
+    stock_code: string,
+    stock_name: string,
+    amount: number,
+    price: number,
+    trade_type: TradeType,
+    created_at: Date,
+  ) {
+    this.stock_code = stock_code;
+    this.stock_name = stock_name;
+    this.amount = amount;
+    this.price = price;
+    this.trade_type = trade_type;
+    this.created_at = created_at;
+  }
+
+  @ApiProperty({ description: '종목 코드' })
+  stock_code: string;
+
+  @ApiProperty({ description: '종목 이름' })
+  stock_name: string;
+
+  @ApiProperty({ description: '매도/매수 희망 수량' })
+  amount: number;
+
+  @ApiProperty({ description: '매도/매수 희망 가격' })
+  price: number;
+
+  @ApiProperty({ description: '매도: SELL, 매수: BUY' })
+  trade_type: TradeType;
+
+  @ApiProperty({ description: '주문 시간' })
+  created_at: Date;
+}

--- a/BE/src/stock/order/interface/request.interface.ts
+++ b/BE/src/stock/order/interface/request.interface.ts
@@ -1,9 +1,0 @@
-export interface RequestInterface {
-  user: {
-    id: number;
-    email: string;
-    password: string;
-    tutorial: boolean;
-    kakaoId: number;
-  };
-}

--- a/BE/src/stock/order/interface/stock-order-raw.interface.ts
+++ b/BE/src/stock/order/interface/stock-order-raw.interface.ts
@@ -1,0 +1,17 @@
+import { StatusType } from '../enum/status-type';
+import { TradeType } from '../enum/trade-type';
+
+export interface StockOrderRawInterface {
+  o_id: number;
+  o_user_id: number;
+  o_stock_code: string;
+  o_trade_type: TradeType;
+  o_amount: number;
+  o_price: number;
+  o_status: StatusType;
+  o_created_at: Date;
+  o_completed_at: Date;
+  s_code: string;
+  s_name: string;
+  s_market: string;
+}

--- a/BE/src/stock/order/stock-order.controller.ts
+++ b/BE/src/stock/order/stock-order.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   Param,
   Post,
   Req,
@@ -18,6 +19,7 @@ import { Request } from 'express';
 import { StockOrderService } from './stock-order.service';
 import { StockOrderRequestDto } from './dto/stock-order-request.dto';
 import { JwtAuthGuard } from '../../auth/jwt-auth-guard';
+import { StockOrderElementResponseDto } from './dto/stock-order-element-response.dto';
 
 @Controller('/api/stocks/trade')
 @ApiTags('주식 매수/매도 API')
@@ -81,6 +83,24 @@ export class StockOrderController {
     await this.stockOrderService.cancel(
       parseInt(request.user.userId, 10),
       orderId,
+    );
+  }
+
+  @Get('/list')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: '미체결 주문 리스트 조회 API',
+    description: '미체결 주문 취소를 위해, 미체결된 주문 리스트를 조회한다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '미체결 주문 리스트 조회 성공',
+    type: [StockOrderElementResponseDto],
+  })
+  async getPendingList(@Req() request: Request) {
+    return this.stockOrderService.getPendingListByUserId(
+      parseInt(request.user.userId, 10),
     );
   }
 }

--- a/BE/src/stock/order/stock-order.repository.ts
+++ b/BE/src/stock/order/stock-order.repository.ts
@@ -5,6 +5,7 @@ import { Order } from './stock-order.entity';
 import { StatusType } from './enum/status-type';
 import { Asset } from '../../asset/asset.entity';
 import { UserStock } from '../../asset/user-stock.entity';
+import { StockOrderRawInterface } from './interface/stock-order-raw.interface';
 
 @Injectable()
 export class StockOrderRepository extends Repository<Order> {
@@ -108,5 +109,12 @@ export class StockOrderRepository extends Repository<Order> {
     } finally {
       await queryRunner.release();
     }
+  }
+
+  async findAllPendingOrdersByUserId(userId: number) {
+    return this.createQueryBuilder('o')
+      .leftJoinAndSelect('stocks', 's', 's.code = o.stock_code')
+      .where({ user_id: userId, status: StatusType.PENDING })
+      .getRawMany<StockOrderRawInterface>();
   }
 }

--- a/BE/src/stock/order/stock-order.repository.ts
+++ b/BE/src/stock/order/stock-order.repository.ts
@@ -29,7 +29,6 @@ export class StockOrderRepository extends Repository<Order> {
         { id: order.id },
         { status: StatusType.COMPLETE, completed_at: new Date() },
       );
-      // TODO: stock_balance와 total_asset은 실시간 주가에 따라 변동하도록 따로 구현해야 함
       await queryRunner.manager
         .createQueryBuilder()
         .update(Asset)
@@ -78,7 +77,6 @@ export class StockOrderRepository extends Repository<Order> {
         { id: order.id },
         { status: StatusType.COMPLETE, completed_at: new Date() },
       );
-      // TODO: stock_balance와 total_asset은 실시간 주가에 따라 변동하도록 따로 구현해야 함
       await queryRunner.manager
         .createQueryBuilder()
         .update(Asset)

--- a/BE/src/stock/order/stock-order.service.ts
+++ b/BE/src/stock/order/stock-order.service.ts
@@ -12,6 +12,7 @@ import { StatusType } from './enum/status-type';
 import { StockOrderSocketService } from './stock-order-socket.service';
 import { UserStockRepository } from '../../asset/user-stock.repository';
 import { AssetRepository } from '../../asset/asset.repository';
+import { StockOrderElementResponseDto } from './dto/stock-order-element-response.dto';
 
 @Injectable()
 export class StockOrderService {
@@ -86,5 +87,21 @@ export class StockOrderService {
       }))
     )
       this.stockOrderSocketService.unsubscribeByCode(order.stock_code);
+  }
+
+  async getPendingListByUserId(userId: number) {
+    const stockOrderRaws =
+      await this.stockOrderRepository.findAllPendingOrdersByUserId(userId);
+
+    return stockOrderRaws.map((stockOrderRaw) => {
+      return new StockOrderElementResponseDto(
+        stockOrderRaw.o_stock_code,
+        stockOrderRaw.s_name,
+        stockOrderRaw.o_amount,
+        stockOrderRaw.o_price,
+        stockOrderRaw.o_trade_type,
+        stockOrderRaw.o_created_at,
+      );
+    });
   }
 }


### PR DESCRIPTION
### ✅ 주요 작업
- [x] 마이페이지 조회 API 구현
- [x] 주식 평가 가격 및 총 자산 1분마다 DB 업데이트하는 로직 구현
- [x] 프로필 조회 API 구현

### 💭 고민과 해결과정
- 원래는 자산을 가지고 있는 종목 가격이 변화할 때마다 업데이트해주는 방식으로 구현해야하나... 생각했었는데 그렇게 되면 엄청 좋겠지만 생각해보니 DB에 접근하는 빈도가 너무 잦아지는 것 같았다.
- 만약 사용자가 한명이라고 쳐도, 한 종목당 1초에 약 2번은 가격이 바뀌는 것 같은데 한 사용자가 20개의 종목을 사두면 자산은 1초에 40번 바뀌어야한다...
- 그래서 일단은 1분마다 현재 가격을 조회해 DB를 업데이트하는 방식으로 구현해두었다. (Redis 쓰면 괜찮아지려나요)

> user-stock asset 통합 이후에 진행한 작업이라서 이전 커밋 포함되어있습니다. #150 붙어있는 커밋만 봐주시면 됩니당.
