### PR TITLE
[BE] 25.05 socket과 sse 비교하기

### DIFF
--- a/BE/src/common/websocket/socket.gateway.ts
+++ b/BE/src/common/websocket/socket.gateway.ts
@@ -21,7 +21,7 @@ export class SocketGateway {
     this.server.emit(event, stockIndexValue);
   }
 
-  sendStockTradeHistoryValueToClient(event, chartData) {
-    this.server.emit(event, chartData);
+  sendStockTradeHistoryValueToClient(event, historyData) {
+    this.server.emit(event, historyData);
   }
 }

--- a/BE/src/stock/trade/history/stock-trade-history-socket.service.ts
+++ b/BE/src/stock/trade/history/stock-trade-history-socket.service.ts
@@ -6,6 +6,7 @@ import { SseEvent } from './interface/sse-event';
 import { SocketConnectTokenInterface } from '../../../common/websocket/interface/socket.interface';
 import { getFullTestURL } from '../../../util/get-full-URL';
 import { TodayStockTradeHistoryDataDto } from './dto/today-stock-trade-history-data.dto';
+import { SocketGateway } from '../../../common/websocket/socket.gateway';
 
 @Injectable()
 export class StockTradeHistorySocketService implements OnModuleInit {
@@ -15,6 +16,8 @@ export class StockTradeHistorySocketService implements OnModuleInit {
   private subscribedStocks = new Set<string>();
   private TR_ID = 'H0STCNT0';
   private eventSubject = new Subject<SseEvent>();
+
+  constructor(private readonly socketGateway: SocketGateway) {}
 
   async onModuleInit() {
     this.socketConnectionKey = await this.getSocketConnectionKey();
@@ -52,10 +55,14 @@ export class StockTradeHistorySocketService implements OnModuleInit {
 
       this.eventSubject.next({
         data: JSON.stringify({
-          stockCode: data[1],
           tradeData,
         }),
       });
+
+      this.socketGateway.sendStockTradeHistoryValueToClient(
+        `trade-history/${dataList[0]}`,
+        tradeData,
+      );
     };
 
     this.socket.onclose = () => {

--- a/BE/src/stock/trade/history/stock-trade-history.controller.ts
+++ b/BE/src/stock/trade/history/stock-trade-history.controller.ts
@@ -30,7 +30,12 @@ export class StockTradeHistoryController {
     type: TodayStockTradeHistoryDataDto,
   })
   getTodayStockTradeHistory(@Param('stockCode') stockCode: string) {
-    return this.stockTradeHistoryService.getTodayStockTradeHistory(stockCode);
+    const data =
+      this.stockTradeHistoryService.getTodayStockTradeHistory(stockCode);
+
+    this.stockTradeHistorySocketService.subscribeByCode(stockCode);
+
+    return data;
   }
 
   @Get(':stockCode/daily')

--- a/BE/src/stock/trade/history/stock-trade-history.controller.ts
+++ b/BE/src/stock/trade/history/stock-trade-history.controller.ts
@@ -85,4 +85,21 @@ export class StockTradeHistoryController {
       };
     });
   }
+
+  @Get(':stockCode/unsubscribe')
+  @ApiOperation({ summary: '페이지를 벗어날 때 구독을 취소하기 위한 API' })
+  @ApiParam({
+    name: 'stockCode',
+    required: true,
+    description:
+      '종목 코드\n\n' +
+      '(ex) 005930 삼성전자 / 005380 현대차 / 001500 현대차증권',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '구독 취소 성공',
+  })
+  unsubscribeCode(@Param('stockCode') stockCode: string) {
+    this.stockTradeHistorySocketService.unsubscribeByCode(stockCode);
+  }
 }


### PR DESCRIPTION
### ✅ 주요 작업
- sse와 달리 api를 호출하면 해당 종목을 구독할 수 있게 했음
- event 이름으로 **`trade-history/{종목코드}`** 를 입력하면 sse와 동일한 데이터를 전달할 수 있게 함
- 페이지를 벗어날 때 구독을 취소해야 하므로 구독 취소를 위한 api 생성**`/api/stocks/trade-history/{stockCode}/unsubscribe`** 

### 💭 고민과 해결과정
- SSE와 동일하게 페이지를 정상적으로 나가지 않는 경우에서도 api 호출을 해서 구독을 제대로 취소할지 고민이 된다.
- SSE는 서버에서 6개째부터 잘 되지 않는 문제 상황이 있었다. (로컬에서는 11개) 이제 이 코드로 로컬에서 테스트 해볼 예정이다..

