### PR TITLE
[BE] 6.02 각 주식 정보 가져오기 기능 구현 (WebSocket)

### DIFF
--- a/BE/src/stock/trade/history/dto/stock-detail-socket-data.dto.ts
+++ b/BE/src/stock/trade/history/dto/stock-detail-socket-data.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StockDetailSocketDataDto {
+  @ApiProperty({ description: '주식 현재가' })
+  stck_prpr: string;
+
+  @ApiProperty({ description: '전일 대비 부호' })
+  prdy_vrss_sign: string;
+
+  @ApiProperty({ description: '전일 대비' })
+  prdy_vrss: string;
+
+  @ApiProperty({ description: '전일 대비율' })
+  prdy_ctrt: string;
+}

--- a/BE/src/stock/trade/history/stock-trade-history-socket.service.ts
+++ b/BE/src/stock/trade/history/stock-trade-history-socket.service.ts
@@ -7,6 +7,7 @@ import { SocketConnectTokenInterface } from '../../../common/websocket/interface
 import { getFullTestURL } from '../../../util/get-full-URL';
 import { TodayStockTradeHistoryDataDto } from './dto/today-stock-trade-history-data.dto';
 import { SocketGateway } from '../../../common/websocket/socket.gateway';
+import { StockDetailSocketDataDto } from './dto/stock-detail-socket-data.dto';
 
 @Injectable()
 export class StockTradeHistorySocketService implements OnModuleInit {
@@ -53,6 +54,13 @@ export class StockTradeHistorySocketService implements OnModuleInit {
         prdy_ctrt: dataList[5],
       };
 
+      const detailData: StockDetailSocketDataDto = {
+        stck_prpr: dataList[2],
+        prdy_vrss_sign: dataList[3],
+        prdy_vrss: dataList[4],
+        prdy_ctrt: dataList[5],
+      };
+
       this.eventSubject.next({
         data: JSON.stringify({
           tradeData,
@@ -62,6 +70,11 @@ export class StockTradeHistorySocketService implements OnModuleInit {
       this.socketGateway.sendStockTradeHistoryValueToClient(
         `trade-history/${dataList[0]}`,
         tradeData,
+      );
+
+      this.socketGateway.sendStockIndexValueToClient(
+        `detail/${dataList[0]}`,
+        detailData,
       );
     };
 


### PR DESCRIPTION
### ✅ 주요 작업
- detail 페이지 상단부에 주식 현재가 부분에 업데이트될 실시간 데이터 웹소켓으로 구현

### 💭 고민과 해결과정
- 주식 현재가가 체결가 기준으로 계속 바뀌는 건지 몰랐다..... 저를 바보라고 불러도 좋습니당....ㅎㅎㅎ
- 현재 같은 tr_id를 가진 웹소켓 요청이어서 **`stock-trade-history-socket.service`** 에 만들었는데 따지고 보면 **`stock/detail`** 디렉터리에 해당하는 부분이라 고민이 많습니다.
  - trade-history도 detail 페이지에 포함되는 내용이니 detail 디렉터리 하단으로 옮기는게 역시 좋을까요?


