### PR TITLE
[BE] 마이페이지 및 주문 API 수정

### DIFF
--- a/BE/src/asset/asset.controller.ts
+++ b/BE/src/asset/asset.controller.ts
@@ -70,7 +70,7 @@ export class AssetController {
   }
 
   @Cron('*/10 9-16 * * 1-5')
-  async updateStockBalance() {
-    await this.assetService.updateStockBalance();
+  async updateAllAssets() {
+    await this.assetService.updateAllAssets();
   }
 }

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -55,6 +55,7 @@ export class AssetService {
       newAsset.total_asset,
       newAsset.total_profit,
       newAsset.total_profit_rate,
+      newAsset.total_profit_rate >= 0,
     );
 
     const response = new MypageResponseDto();
@@ -64,7 +65,7 @@ export class AssetService {
     return response;
   }
 
-  async updateStockBalance() {
+  async updateAllAssets() {
     const currPrices = await this.getCurrPrices();
     const assets = await this.assetRepository.find();
 
@@ -89,6 +90,8 @@ export class AssetService {
       ...asset,
       stock_balance: totalPrice,
       total_asset: asset.cash_balance + totalPrice,
+      total_profit: asset.cash_balance + totalPrice - 10000000,
+      total_profit_rate: (asset.cash_balance + totalPrice - 10000000) / 100000,
       last_updated: new Date(),
       prev_total_asset: asset.total_asset,
     };

--- a/BE/src/asset/dto/asset-response.dto.ts
+++ b/BE/src/asset/dto/asset-response.dto.ts
@@ -7,12 +7,14 @@ export class AssetResponseDto {
     total_asset,
     total_profit,
     total_profit_rate,
+    is_positive,
   ) {
     this.cash_balance = cash_balance;
     this.stock_balance = stock_balance;
     this.total_asset = total_asset;
     this.total_profit = total_profit;
     this.total_profit_rate = total_profit_rate;
+    this.is_positive = is_positive;
   }
 
   @ApiProperty({ description: '보유 현금' })
@@ -29,4 +31,7 @@ export class AssetResponseDto {
 
   @ApiProperty({ description: '총 수익률' })
   total_profit_rate: number;
+
+  @ApiProperty({ description: '수익률 부호' })
+  is_positive: boolean;
 }

--- a/BE/src/stock/order/dto/stock-order-element-response.dto.ts
+++ b/BE/src/stock/order/dto/stock-order-element-response.dto.ts
@@ -3,6 +3,7 @@ import { TradeType } from '../enum/trade-type';
 
 export class StockOrderElementResponseDto {
   constructor(
+    id: number,
     stock_code: string,
     stock_name: string,
     amount: number,
@@ -10,6 +11,7 @@ export class StockOrderElementResponseDto {
     trade_type: TradeType,
     created_at: Date,
   ) {
+    this.id = id;
     this.stock_code = stock_code;
     this.stock_name = stock_name;
     this.amount = amount;
@@ -17,6 +19,9 @@ export class StockOrderElementResponseDto {
     this.trade_type = trade_type;
     this.created_at = created_at;
   }
+
+  @ApiProperty({ description: '주문 id' })
+  id: number;
 
   @ApiProperty({ description: '종목 코드' })
   stock_code: string;

--- a/BE/src/stock/order/stock-order.controller.ts
+++ b/BE/src/stock/order/stock-order.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Request } from 'express';
+import { Cron } from '@nestjs/schedule';
 import { StockOrderService } from './stock-order.service';
 import { StockOrderRequestDto } from './dto/stock-order-request.dto';
 import { JwtAuthGuard } from '../../auth/jwt-auth-guard';
@@ -102,5 +103,10 @@ export class StockOrderController {
     return this.stockOrderService.getPendingListByUserId(
       parseInt(request.user.userId, 10),
     );
+  }
+
+  @Cron('0 6 * * *')
+  async cronRemovePendingOrders() {
+    await this.stockOrderService.removePendingOrders();
   }
 }

--- a/BE/src/stock/order/stock-order.controller.ts
+++ b/BE/src/stock/order/stock-order.controller.ts
@@ -22,7 +22,7 @@ import { StockOrderRequestDto } from './dto/stock-order-request.dto';
 import { JwtAuthGuard } from '../../auth/jwt-auth-guard';
 import { StockOrderElementResponseDto } from './dto/stock-order-element-response.dto';
 
-@Controller('/api/stocks/trade')
+@Controller('/api/stocks/order')
 @ApiTags('주식 매수/매도 API')
 export class StockOrderController {
   constructor(private readonly stockOrderService: StockOrderService) {}

--- a/BE/src/stock/order/stock-order.controller.ts
+++ b/BE/src/stock/order/stock-order.controller.ts
@@ -105,7 +105,7 @@ export class StockOrderController {
     );
   }
 
-  @Cron('0 6 * * *')
+  @Cron('0 18 * * *')
   async cronRemovePendingOrders() {
     await this.stockOrderService.removePendingOrders();
   }

--- a/BE/src/stock/order/stock-order.repository.ts
+++ b/BE/src/stock/order/stock-order.repository.ts
@@ -35,9 +35,6 @@ export class StockOrderRepository extends Repository<Order> {
         .update(Asset)
         .set({
           cash_balance: () => `cash_balance - :realPrice`,
-          total_asset: () => `total_asset - :realPrice`,
-          total_profit: () => `total_profit - :realPrice`,
-          total_profit_rate: () => `total_profit / 10000000`,
           last_updated: new Date(),
         })
         .where({ user_id: order.user_id })
@@ -83,9 +80,6 @@ export class StockOrderRepository extends Repository<Order> {
         .update(Asset)
         .set({
           cash_balance: () => `cash_balance + :realPrice`,
-          total_asset: () => `total_asset + :realPrice`,
-          total_profit: () => `total_profit + :realPrice`,
-          total_profit_rate: () => `total_profit / 10000000`,
           last_updated: new Date(),
         })
         .where({ user_id: order.user_id })

--- a/BE/src/stock/order/stock-order.service.ts
+++ b/BE/src/stock/order/stock-order.service.ts
@@ -13,6 +13,7 @@ import { StockOrderSocketService } from './stock-order-socket.service';
 import { UserStockRepository } from '../../asset/user-stock.repository';
 import { AssetRepository } from '../../asset/asset.repository';
 import { StockOrderElementResponseDto } from './dto/stock-order-element-response.dto';
+import { Order } from './stock-order.entity';
 
 @Injectable()
 export class StockOrderService {
@@ -104,5 +105,18 @@ export class StockOrderService {
         stockOrderRaw.o_created_at,
       );
     });
+  }
+
+  async removePendingOrders() {
+    const orders: Order[] =
+      await this.stockOrderRepository.findAllCodeByStatus();
+
+    await Promise.all(
+      orders.map((order) =>
+        this.stockOrderSocketService.unsubscribeByCode(order.stock_code),
+      ),
+    );
+
+    await this.stockOrderRepository.delete({ status: StatusType.PENDING });
   }
 }

--- a/BE/src/stock/order/stock-order.service.ts
+++ b/BE/src/stock/order/stock-order.service.ts
@@ -95,6 +95,7 @@ export class StockOrderService {
 
     return stockOrderRaws.map((stockOrderRaw) => {
       return new StockOrderElementResponseDto(
+        stockOrderRaw.o_id,
         stockOrderRaw.o_stock_code,
         stockOrderRaw.s_name,
         stockOrderRaw.o_amount,


### PR DESCRIPTION
### ✅ 주요 작업
- [x] 미체결 주문 리스트 반환값에 id 추가
- [x] 수익금 수익률 계산 수정
- [x] 수익률 부호 flag 추가
- [x] 매일 18시에 미체결 주문 삭제 스케줄러 추가
- [x] 매도/매수 API 엔드포인트 변경
- [x] 메소드명 잘못된거 수정

### 💭 고민과 해결과정
- 미체결 주문을 실제로 언제 취소시키나 검색했는데 시간 외 단일가 거래 마감 시간인 18시에 모두 취소한다고 해서 똑같이 18시로 구현했다. 주문 등록 시간을 막아놓지 않아서 주말에도 등록이 될 수 있기 때문에, 주말도 포함해서 18시에 삭제하는 것으로 결정했다.