### PR TITLE
[BE] 🔧 fix : query 별로 응답이 아닌 한번의 요청에 두개의 랭킹 모두 응답하게 변경(#124)

### DIFF
--- a/BE/src/ranking/dto/ranking-data.dto.ts
+++ b/BE/src/ranking/dto/ranking-data.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RankingDataDto {
+  @ApiProperty({
+    description: '사용자 닉네임',
+    example: 'trader123',
+  })
+  nickname: string;
+
+  @ApiProperty({
+    description: '수익률 (%)',
+    example: 15.7,
+    required: false,
+  })
+  profitRate?: number;
+
+  @ApiProperty({
+    description: '총 자산',
+    example: 1000000,
+    required: false,
+  })
+  totalAsset?: number;
+}

--- a/BE/src/ranking/dto/ranking-response.dto.ts
+++ b/BE/src/ranking/dto/ranking-response.dto.ts
@@ -1,13 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { RankingResultDto } from './ranking-result.dto';
 
 export class RankingResponseDto {
   @ApiProperty({
-    description: 'top 10 유저 랭킹',
+    description: '수익률 랭킹',
   })
-  topRank: string[];
+  profitRateRanking: RankingResultDto;
 
   @ApiProperty({
-    description: '로그인 한 유저의 랭킹',
+    description: '자산 랭킹',
   })
-  userRank?: number | null;
+  assetRanking: RankingResultDto;
 }

--- a/BE/src/ranking/dto/ranking-result.dto.ts
+++ b/BE/src/ranking/dto/ranking-result.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { RankingDataDto } from './ranking-data.dto';
+
+export class RankingResultDto {
+  @ApiProperty({
+    description: '상위 10명의 랭킹 데이터',
+    type: [RankingDataDto],
+  })
+  topRank: RankingDataDto[];
+
+  @ApiProperty({
+    description: '현재 사용자의 순위 (없을 경우 null)',
+    example: 42,
+    nullable: true,
+  })
+  userRank: number | null;
+}

--- a/BE/src/ranking/interface/ranking-data.interface.ts
+++ b/BE/src/ranking/interface/ranking-data.interface.ts
@@ -1,5 +1,0 @@
-export interface RankingData {
-  nickname: string;
-  profitRate?: number;
-  totalAsset?: number;
-}

--- a/BE/src/ranking/interface/ranking-data.interface.ts
+++ b/BE/src/ranking/interface/ranking-data.interface.ts
@@ -1,0 +1,5 @@
+export interface RankingData {
+  nickname: string;
+  profitRate?: number;
+  totalAsset?: number;
+}

--- a/BE/src/ranking/ranking.controller.ts
+++ b/BE/src/ranking/ranking.controller.ts
@@ -1,10 +1,9 @@
-import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { OptionalAuthGuard } from 'src/auth/optional-auth-guard';
 import { RankingService } from './ranking.service';
 import { RankingResponseDto } from './dto/ranking-response.dto';
-import { SortType } from './enum/sort-type.enum';
 
 @Controller('/api/ranking')
 @ApiTags('랭킹 API')
@@ -22,18 +21,13 @@ export class RankingController {
   @ApiQuery({
     name: 'sortBy',
     required: false,
-    description: 'profitRate: 수익률순, totalAsset: 자산순',
-    enum: ['profitRate', 'totalAsset'],
   })
-  async getRanking(
-    @Req() req: Request,
-    @Query('sortBy') sortBy: SortType = SortType.PROFIT_RATE,
-  ): Promise<RankingResponseDto> {
+  async getRanking(@Req() req: Request): Promise<RankingResponseDto> {
     if (!req.user) {
-      return this.rankingService.getRanking(sortBy);
+      return this.rankingService.getRanking();
     }
 
     const { nickname } = req.user;
-    return this.rankingService.getRankingAuthUser(nickname, sortBy);
+    return this.rankingService.getRankingAuthUser(nickname);
   }
 }

--- a/BE/src/ranking/ranking.controller.ts
+++ b/BE/src/ranking/ranking.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { OptionalAuthGuard } from 'src/auth/optional-auth-guard';
 import { RankingService } from './ranking.service';
@@ -18,10 +18,6 @@ export class RankingController {
   })
   @Get()
   @UseGuards(OptionalAuthGuard)
-  @ApiQuery({
-    name: 'sortBy',
-    required: false,
-  })
   async getRanking(@Req() req: Request): Promise<RankingResponseDto> {
     if (!req.user) {
       return this.rankingService.getRanking();


### PR DESCRIPTION
### ✅ 주요 작업
- [x] query 별로 요청하는 게 아닌 한번의 요청에 totalAsset, profitRate 모두 응답하게 변경
