### PR TITLE
[BE] 26.06 마이페이지 웹소켓 구독 로직 추가 #180

### DIFF
--- a/BE/src/asset/asset.controller.ts
+++ b/BE/src/asset/asset.controller.ts
@@ -71,6 +71,19 @@ export class AssetController {
     return this.assetService.getMyPage(parseInt(request.user.userId, 10));
   }
 
+  @Get('/unsubscribe')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: '마이페이지 내 주식 소켓 연결 취소 API',
+    description: '마이페이지에서 나갈 때 소켓 연결 취소를 위한 API',
+  })
+  async unsubscribeMyStocks(@Req() request: Request) {
+    await this.assetService.unsubscribeMyStocks(
+      parseInt(request.user.userId, 10),
+    );
+  }
+
   @Cron('*/10 9-16 * * 1-5')
   async updateAllAssets() {
     await this.assetService.updateAllAssets();

--- a/BE/src/asset/asset.controller.ts
+++ b/BE/src/asset/asset.controller.ts
@@ -20,13 +20,14 @@ export class AssetController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @ApiOperation({
-    summary: '매도 가능 주식 개수 조회 API',
-    description: '특정 주식 매도 시에 필요한 매도 가능한 주식 개수를 조회한다.',
+    summary: '매도 가능 주식 개수, 매수 평균가 조회 API',
+    description:
+      '특정 주식 매도 시에 필요한 매도 가능한 주식 개수와 매수 평균가를 조회한다.',
   })
   @ApiResponse({
     status: 200,
-    description: '매도 가능 주식 개수 조회 성공',
-    example: { quantity: 0 },
+    description: '매도 가능 주식 개수 및 매수 평균가 조회 성공',
+    example: { quantity: 0, avg_price: 0 },
   })
   async getUserStockByCode(
     @Req() request: Request,

--- a/BE/src/asset/asset.module.ts
+++ b/BE/src/asset/asset.module.ts
@@ -7,9 +7,14 @@ import { Asset } from './asset.entity';
 import { UserStock } from './user-stock.entity';
 import { UserStockRepository } from './user-stock.repository';
 import { StockDetailModule } from '../stock/detail/stock-detail.module';
+import { StockTradeHistoryModule } from '../stock/trade/history/stock-trade-history.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Asset, UserStock]), StockDetailModule],
+  imports: [
+    TypeOrmModule.forFeature([Asset, UserStock]),
+    StockDetailModule,
+    StockTradeHistoryModule,
+  ],
   controllers: [AssetController],
   providers: [AssetService, AssetRepository, UserStockRepository],
   exports: [AssetRepository, UserStockRepository],

--- a/BE/src/asset/asset.repository.ts
+++ b/BE/src/asset/asset.repository.ts
@@ -19,13 +19,13 @@ export class AssetRepository extends Repository<Asset> {
       .getRawMany();
   }
 
-  async findAllPendingOrders(userId: number) {
+  async findAllPendingOrders(userId: number, tradeType: TradeType) {
     const queryRunner = this.dataSource.createQueryRunner();
     return queryRunner.manager.find<Order>(Order, {
       where: {
         user_id: userId,
         status: StatusType.PENDING,
-        trade_type: TradeType.BUY,
+        trade_type: tradeType,
       },
     });
   }

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -9,6 +9,9 @@ import { UserStock } from './user-stock.entity';
 import { Asset } from './asset.entity';
 import { InquirePriceResponseDto } from '../stock/detail/dto/stock-detail-response.dto';
 import { StockTradeHistorySocketService } from '../stock/trade/history/stock-trade-history-socket.service';
+import { StatusType } from '../stock/order/enum/status-type';
+import { TradeType } from '../stock/order/enum/trade-type';
+import { Order } from '../stock/order/stock-order.entity';
 
 @Injectable()
 export class AssetService {
@@ -33,8 +36,14 @@ export class AssetService {
 
   async getCashBalance(userId: number) {
     const asset = await this.assetRepository.findOneBy({ user_id: userId });
+    const pendingOrders =
+      await this.assetRepository.findAllPendingOrders(userId);
+    const totalPendingPrice = pendingOrders.reduce(
+      (sum, pendingOrder) => sum + pendingOrder.price * pendingOrder.amount,
+      0,
+    );
 
-    return { cash_balance: asset.cash_balance };
+    return { cash_balance: asset.cash_balance - totalPendingPrice };
   }
 
   async getMyPage(userId: number) {

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -7,6 +7,8 @@ import { AssetResponseDto } from './dto/asset-response.dto';
 import { StockDetailService } from '../stock/detail/stock-detail.service';
 import { UserStock } from './user-stock.entity';
 import { Asset } from './asset.entity';
+import { InquirePriceResponseDto } from '../stock/detail/dto/stock-detail-response.dto';
+import { StockTradeHistorySocketService } from '../stock/trade/history/stock-trade-history-socket.service';
 
 @Injectable()
 export class AssetService {
@@ -14,6 +16,7 @@ export class AssetService {
     private readonly userStockRepository: UserStockRepository,
     private readonly assetRepository: AssetRepository,
     private readonly stockDetailService: StockDetailService,
+    private readonly stockTradeHistorySocketService: StockTradeHistorySocketService,
   ) {}
 
   async getUserStockByCode(userId: number, stockCode: string) {
@@ -35,17 +38,21 @@ export class AssetService {
     const userStocks =
       await this.userStockRepository.findUserStockWithNameByUserId(userId);
     const asset = await this.assetRepository.findOneBy({ user_id: userId });
-    const newAsset = await this.updateMyAsset(
-      asset,
-      await this.getCurrPrices(),
-    );
+    const currPrices = await this.getCurrPrices(userId);
+    const newAsset = await this.updateMyAsset(asset, currPrices);
 
     const myStocks = userStocks.map((userStock) => {
+      const currPrice: InquirePriceResponseDto =
+        currPrices[userStock.stocks_code];
       return new StockElementResponseDto(
         userStock.stocks_name,
         userStock.stocks_code,
         userStock.user_stocks_quantity,
-        userStock.user_stocks_avg_price,
+        Number(userStock.user_stocks_avg_price),
+        currPrice.stck_prpr,
+        currPrice.prdy_vrss,
+        currPrice.prdy_vrss_sign,
+        currPrice.prdy_ctrt,
       );
     });
 
@@ -61,6 +68,8 @@ export class AssetService {
     const response = new MypageResponseDto();
     response.asset = myAsset;
     response.stocks = myStocks;
+
+    await this.subscribeMyStocks(userId);
 
     return response;
   }
@@ -82,7 +91,8 @@ export class AssetService {
 
     const totalPrice = userStocks.reduce(
       (sum, userStock) =>
-        sum + userStock.quantity * currPrices[userStock.stock_code],
+        sum +
+        userStock.quantity * Number(currPrices[userStock.stock_code].stck_prpr),
       0,
     );
 
@@ -98,20 +108,38 @@ export class AssetService {
     return this.assetRepository.save(updatedAsset);
   }
 
-  private async getCurrPrices() {
+  private async getCurrPrices(userId?: number) {
     const userStocks: UserStock[] =
-      await this.userStockRepository.findAllDistinctCode();
+      await this.userStockRepository.findAllDistinctCode(userId);
     const currPrices = {};
 
     await Promise.allSettled(
       userStocks.map(async (userStock) => {
-        const inquirePrice = await this.stockDetailService.getInquirePrice(
-          userStock.stock_code,
-        );
-        currPrices[userStock.stock_code] = Number(inquirePrice.stck_prpr);
+        currPrices[userStock.stock_code] =
+          await this.stockDetailService.getInquirePrice(userStock.stock_code);
       }),
     );
 
     return currPrices;
+  }
+
+  private async subscribeMyStocks(userId: number) {
+    const userStocks: UserStock[] =
+      await this.userStockRepository.findAllDistinctCode(userId);
+
+    userStocks.map((userStock) =>
+      this.stockTradeHistorySocketService.subscribeByCode(userStock.stock_code),
+    );
+  }
+
+  async unsubscribeMyStocks(userId: number) {
+    const userStocks: UserStock[] =
+      await this.userStockRepository.findAllDistinctCode(userId);
+
+    userStocks.map((userStock) =>
+      this.stockTradeHistorySocketService.unsubscribeByCode(
+        userStock.stock_code,
+      ),
+    );
   }
 }

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -25,7 +25,10 @@ export class AssetService {
       stock_code: stockCode,
     });
 
-    return { quantity: userStock ? userStock.quantity : 0 };
+    return {
+      quantity: userStock ? userStock.quantity : 0,
+      avg_price: userStock ? userStock.avg_price : 0,
+    };
   }
 
   async getCashBalance(userId: number) {

--- a/BE/src/asset/dto/stock-element-response.dto.ts
+++ b/BE/src/asset/dto/stock-element-response.dto.ts
@@ -1,11 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class StockElementResponseDto {
-  constructor(name, code, quantity, avg_price) {
+  constructor(
+    name: string,
+    code: string,
+    quantity: number,
+    avg_price: number,
+    stck_prpr: string,
+    prdy_vrss: string,
+    prdy_vrss_sign: string,
+    prdy_ctrt: string,
+  ) {
     this.name = name;
     this.code = code;
     this.quantity = quantity;
     this.avg_price = avg_price;
+    this.stck_prpr = stck_prpr;
+    this.prdy_vrss = prdy_vrss;
+    this.prdy_vrss_sign = prdy_vrss_sign;
+    this.prdy_ctrt = prdy_ctrt;
   }
 
   @ApiProperty({ description: '종목 이름' })
@@ -19,4 +32,16 @@ export class StockElementResponseDto {
 
   @ApiProperty({ description: '평균 매수가' })
   avg_price: number;
+
+  @ApiProperty({ description: '주식 현재가' })
+  stck_prpr: string;
+
+  @ApiProperty({ description: '전일 대비' })
+  prdy_vrss: string;
+
+  @ApiProperty({ description: '전일 대비 부호' })
+  prdy_vrss_sign: string;
+
+  @ApiProperty({ description: '전일 대비율' })
+  prdy_ctrt: string;
 }

--- a/BE/src/asset/user-stock.repository.ts
+++ b/BE/src/asset/user-stock.repository.ts
@@ -21,10 +21,13 @@ export class UserStockRepository extends Repository<UserStock> {
       .getRawMany<UserStockInterface>();
   }
 
-  findAllDistinctCode() {
-    return this.createQueryBuilder('user_stocks')
+  findAllDistinctCode(userId?: number) {
+    const queryBuilder = this.createQueryBuilder('user_stocks')
       .select('DISTINCT user_stocks.stock_code')
-      .where({ quantity: MoreThan(0) })
-      .getRawMany();
+      .where({ quantity: MoreThan(0) });
+
+    if (userId) queryBuilder.andWhere({ user_id: userId });
+
+    return queryBuilder.getRawMany();
   }
 }

--- a/BE/src/stock/order/stock-order-socket.service.ts
+++ b/BE/src/stock/order/stock-order-socket.service.ts
@@ -107,13 +107,13 @@ export class StockOrderSocketService {
   }
 
   private calculateFee(totalPrice: number) {
-    if (totalPrice <= 10000000) return totalPrice * 0.16;
+    if (totalPrice <= 10000000) return Math.floor(totalPrice * 0.16);
     if (totalPrice > 10000000 && totalPrice <= 50000000)
-      return totalPrice * 0.14;
+      return Math.floor(totalPrice * 0.14);
     if (totalPrice > 50000000 && totalPrice <= 100000000)
-      return totalPrice * 0.12;
+      return Math.floor(totalPrice * 0.12);
     if (totalPrice > 100000000 && totalPrice <= 300000000)
-      return totalPrice * 0.1;
-    return totalPrice * 0.08;
+      return Math.floor(totalPrice * 0.1);
+    return Math.floor(totalPrice * 0.08);
   }
 }

--- a/BE/src/stock/order/stock-order.service.ts
+++ b/BE/src/stock/order/stock-order.service.ts
@@ -62,8 +62,21 @@ export class StockOrderService {
       user_id: userId,
       stock_code: stockOrderRequest.stock_code,
     });
+    const pendingOrders = await this.stockOrderRepository.findBy({
+      user_id: userId,
+      status: StatusType.PENDING,
+      trade_type: TradeType.SELL,
+      stock_code: stockOrderRequest.stock_code,
+    });
+    const totalPendingCount = pendingOrders.reduce(
+      (sum, pendingOrder) => sum + pendingOrder.amount,
+      0,
+    );
 
-    if (!userStock || userStock.quantity < stockOrderRequest.amount)
+    if (
+      !userStock ||
+      userStock.quantity < stockOrderRequest.amount + totalPendingCount
+    )
       throw new BadRequestException('주식을 매도 수만큼 가지고 있지 않습니다.');
 
     const order = this.stockOrderRepository.create({

--- a/BE/src/stock/trade/history/stock-trade-history.module.ts
+++ b/BE/src/stock/trade/history/stock-trade-history.module.ts
@@ -9,5 +9,6 @@ import { SocketModule } from '../../../common/websocket/socket.module';
   imports: [KoreaInvestmentModule, SocketModule],
   controllers: [StockTradeHistoryController],
   providers: [StockTradeHistoryService, StockTradeHistorySocketService],
+  exports: [StockTradeHistorySocketService],
 })
 export class StockTradeHistoryModule {}


### PR DESCRIPTION
### ✅ 주요 작업
- [x] 마이페이지 웹소켓 구독 로직 추가
- [x] 수수료 내림 처리 로직 추가
- [x] 매도 가능 주식 개수 조회 API에 매수 평균가 추가
- [x] 매수/매도 주문 시 pending order도 확인하도록 변경

### 💭 고민과 해결과정
- 마이페이지 조회 API를 호출하면 보유하고 있는 주식 종목들에 대해 구독을 시작하고,(이벤트: `detail/{종목코드}`) 보유 종목들에 대해 구독을 취소하는 API를 추가했습니다. 구독 취소 API는 페이지에서 벗어날 때 클라이언트에서 호출해주면 될 것 같습니다.
