### PR TITLE
[BE] 11.03, 12.03, 13.03 종목 즐겨찾기 API 구현 #177, #178, #179

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -18,6 +18,7 @@ import { StockTradeHistoryModule } from './stock/trade/history/stock-trade-histo
 import { RedisModule } from './common/redis/redis.module';
 import { HTTPExceptionFilter } from './common/filters/http-exception.filter';
 import { RankingModule } from './ranking/ranking.module';
+import { StockBookmarkModule } from './stock/bookmark/stock-bookmark.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { RankingModule } from './ranking/ranking.module';
     StockTradeHistoryModule,
     RedisModule,
     RankingModule,
+    StockBookmarkModule,
   ],
   controllers: [AppController],
   providers: [

--- a/BE/src/stock/bookmark/dto/stock-bookmark-response,dto.ts
+++ b/BE/src/stock/bookmark/dto/stock-bookmark-response,dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StockBookmarkResponseDto {
+  constructor(
+    name: string,
+    code: string,
+    stck_prpr: string,
+    prdy_vrss: string,
+    prdy_vrss_sign: string,
+    prdy_ctrt: string,
+  ) {
+    this.name = name;
+    this.code = code;
+    this.stck_prpr = stck_prpr;
+    this.prdy_vrss = prdy_vrss;
+    this.prdy_vrss_sign = prdy_vrss_sign;
+    this.prdy_ctrt = prdy_ctrt;
+  }
+
+  @ApiProperty({ description: '종목 이름' })
+  name: string;
+
+  @ApiProperty({ description: '종목 코드' })
+  code: string;
+
+  @ApiProperty({ description: '주식 현재가' })
+  stck_prpr: string;
+
+  @ApiProperty({ description: '전일 대비' })
+  prdy_vrss: string;
+
+  @ApiProperty({ description: '전일 대비 부호' })
+  prdy_vrss_sign: string;
+
+  @ApiProperty({ description: '전일 대비율' })
+  prdy_ctrt: string;
+}

--- a/BE/src/stock/bookmark/interface/bookmark.interface.ts
+++ b/BE/src/stock/bookmark/interface/bookmark.interface.ts
@@ -1,0 +1,8 @@
+export interface BookmarkInterface {
+  b_id: number;
+  b_user_id: number;
+  b_stock_code: string;
+  s_code: string;
+  s_name: string;
+  s_market: string;
+}

--- a/BE/src/stock/bookmark/stock-bookmark.controller.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.controller.ts
@@ -1,9 +1,34 @@
-import { Controller } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Controller, Param, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Request } from 'express';
 import { StockBookmarkService } from './stock-bookmark.service';
+import { JwtAuthGuard } from '../../auth/jwt-auth-guard';
 
 @Controller('/api/stocks/bookmark')
 @ApiTags('주식 즐겨찾기 API')
 export class StockBookmarkController {
   constructor(private readonly stockBookmarkService: StockBookmarkService) {}
+
+  @Post('/:stockCode')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '종목 즐겨찾기 등록 API' })
+  @ApiResponse({
+    status: 201,
+    description: '종목 즐겨찾기 등록 성공',
+  })
+  async postBookmark(
+    @Req() request: Request,
+    @Param('stockCode') stockCode: string,
+  ) {
+    await this.stockBookmarkService.registerBookmark(
+      parseInt(request.user.userId, 10),
+      stockCode,
+    );
+  }
 }

--- a/BE/src/stock/bookmark/stock-bookmark.controller.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Delete,
+  Get,
   Param,
   Post,
   Req,
@@ -54,6 +55,20 @@ export class StockBookmarkController {
     await this.stockBookmarkService.unregisterBookmark(
       parseInt(request.user.userId, 10),
       stockCode,
+    );
+  }
+
+  @Get()
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '즐겨찾기 리스트 조회 API' })
+  @ApiResponse({
+    status: 200,
+    description: '즐겨찾기 리스트 조회 성공',
+  })
+  async getBookmarkList(@Req() request: Request) {
+    return this.stockBookmarkService.getBookmarkList(
+      parseInt(request.user.userId, 10),
     );
   }
 }

--- a/BE/src/stock/bookmark/stock-bookmark.controller.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { StockBookmarkService } from './stock-bookmark.service';
+
+@Controller('/api/stocks/bookmark')
+@ApiTags('주식 즐겨찾기 API')
+export class StockBookmarkController {
+  constructor(private readonly stockBookmarkService: StockBookmarkService) {}
+}

--- a/BE/src/stock/bookmark/stock-bookmark.controller.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Param, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Delete,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -27,6 +34,24 @@ export class StockBookmarkController {
     @Param('stockCode') stockCode: string,
   ) {
     await this.stockBookmarkService.registerBookmark(
+      parseInt(request.user.userId, 10),
+      stockCode,
+    );
+  }
+
+  @Delete('/:stockCode')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '종목 즐겨찾기 취소 API' })
+  @ApiResponse({
+    status: 200,
+    description: '종목 즐겨찾기 취소 성공',
+  })
+  async deleteBookmark(
+    @Req() request: Request,
+    @Param('stockCode') stockCode: string,
+  ) {
+    await this.stockBookmarkService.unregisterBookmark(
       parseInt(request.user.userId, 10),
       stockCode,
     );

--- a/BE/src/stock/bookmark/stock-bookmark.controller.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.controller.ts
@@ -16,6 +16,7 @@ import {
 import { Request } from 'express';
 import { StockBookmarkService } from './stock-bookmark.service';
 import { JwtAuthGuard } from '../../auth/jwt-auth-guard';
+import { StockBookmarkResponseDto } from './dto/stock-bookmark-response,dto';
 
 @Controller('/api/stocks/bookmark')
 @ApiTags('주식 즐겨찾기 API')
@@ -65,6 +66,7 @@ export class StockBookmarkController {
   @ApiResponse({
     status: 200,
     description: '즐겨찾기 리스트 조회 성공',
+    type: [StockBookmarkResponseDto],
   })
   async getBookmarkList(@Req() request: Request) {
     return this.stockBookmarkService.getBookmarkList(

--- a/BE/src/stock/bookmark/stock-bookmark.controller.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.controller.ts
@@ -73,4 +73,23 @@ export class StockBookmarkController {
       parseInt(request.user.userId, 10),
     );
   }
+
+  @Get('/:stockCode')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '특정 종목에 대한 즐겨찾기 등록 여부 조회 API' })
+  @ApiResponse({
+    status: 200,
+    description: '즐겨찾기 등록 여부 조회 성공',
+    example: { is_bookmarked: true },
+  })
+  async getBookmarkActive(
+    @Req() request: Request,
+    @Param('stockCode') stockCode: string,
+  ) {
+    return this.stockBookmarkService.getBookmarkActive(
+      parseInt(request.user.userId, 10),
+      stockCode,
+    );
+  }
 }

--- a/BE/src/stock/bookmark/stock-bookmark.entity.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.entity.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('bookmarks')
+export class Bookmark {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: false })
+  stock_code: string;
+
+  @Column({ nullable: false })
+  user_id: number;
+}

--- a/BE/src/stock/bookmark/stock-bookmark.module.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Bookmark } from './stock-bookmark.entity';
+import { StockBookmarkController } from './stock-bookmark.controller';
+import { StockBookmarkRepository } from './stock-bookmark.repository';
+import { StockBookmarkService } from './stock-bookmark.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Bookmark])],
+  controllers: [StockBookmarkController],
+  providers: [StockBookmarkRepository, StockBookmarkService],
+})
+export class StockBookmarkModule {}

--- a/BE/src/stock/bookmark/stock-bookmark.module.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.module.ts
@@ -4,9 +4,10 @@ import { Bookmark } from './stock-bookmark.entity';
 import { StockBookmarkController } from './stock-bookmark.controller';
 import { StockBookmarkRepository } from './stock-bookmark.repository';
 import { StockBookmarkService } from './stock-bookmark.service';
+import { StockDetailModule } from '../detail/stock-detail.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Bookmark])],
+  imports: [TypeOrmModule.forFeature([Bookmark]), StockDetailModule],
   controllers: [StockBookmarkController],
   providers: [StockBookmarkRepository, StockBookmarkService],
 })

--- a/BE/src/stock/bookmark/stock-bookmark.repository.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.repository.ts
@@ -1,0 +1,11 @@
+import { DataSource, Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { Bookmark } from './stock-bookmark.entity';
+
+@Injectable()
+export class StockBookmarkRepository extends Repository<Bookmark> {
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {
+    super(Bookmark, dataSource.createEntityManager());
+  }
+}

--- a/BE/src/stock/bookmark/stock-bookmark.repository.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.repository.ts
@@ -2,10 +2,18 @@ import { DataSource, Repository } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { Bookmark } from './stock-bookmark.entity';
+import { BookmarkInterface } from './interface/bookmark.interface';
 
 @Injectable()
 export class StockBookmarkRepository extends Repository<Bookmark> {
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {
     super(Bookmark, dataSource.createEntityManager());
+  }
+
+  async findBookmarkWithNameByUserId(userId) {
+    return this.createQueryBuilder('b')
+      .leftJoinAndSelect('stocks', 's', 's.code = b.stock_code')
+      .where('b.user_id = :userId', { userId })
+      .getRawMany<BookmarkInterface>();
   }
 }

--- a/BE/src/stock/bookmark/stock-bookmark.service.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { StockBookmarkRepository } from './stock-bookmark.repository';
+
+@Injectable()
+export class StockBookmarkService {
+  constructor(
+    private readonly stockBookmarkRepository: StockBookmarkRepository,
+  ) {}
+}

--- a/BE/src/stock/bookmark/stock-bookmark.service.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.service.ts
@@ -62,4 +62,13 @@ export class StockBookmarkService {
       }),
     );
   }
+
+  async getBookmarkActive(userId, stockCode) {
+    return {
+      is_bookmarked: await this.stockBookmarkRepository.existsBy({
+        user_id: userId,
+        stock_code: stockCode,
+      }),
+    };
+  }
 }

--- a/BE/src/stock/bookmark/stock-bookmark.service.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { StockBookmarkRepository } from './stock-bookmark.repository';
 
 @Injectable()
@@ -6,4 +6,20 @@ export class StockBookmarkService {
   constructor(
     private readonly stockBookmarkRepository: StockBookmarkRepository,
   ) {}
+
+  async registerBookmark(userId, stockCode) {
+    if (
+      await this.stockBookmarkRepository.existsBy({
+        user_id: userId,
+        stock_code: stockCode,
+      })
+    )
+      throw new BadRequestException('이미 등록된 즐겨찾기입니다.');
+
+    const bookmark = this.stockBookmarkRepository.create({
+      user_id: userId,
+      stock_code: stockCode,
+    });
+    await this.stockBookmarkRepository.insert(bookmark);
+  }
 }

--- a/BE/src/stock/bookmark/stock-bookmark.service.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { StockBookmarkRepository } from './stock-bookmark.repository';
 
 @Injectable()
@@ -21,5 +25,16 @@ export class StockBookmarkService {
       stock_code: stockCode,
     });
     await this.stockBookmarkRepository.insert(bookmark);
+  }
+
+  async unregisterBookmark(userId, stockCode) {
+    const bookmark = await this.stockBookmarkRepository.findOneBy({
+      user_id: userId,
+      stock_code: stockCode,
+    });
+
+    if (!bookmark) throw new NotFoundException('존재하지 않는 북마크입니다.');
+
+    await this.stockBookmarkRepository.remove(bookmark);
   }
 }


### PR DESCRIPTION
### ✅ 주요 작업
- [x] 주식 즐겨찾기 등록 API 구현
- [x] 주식 즐겨찾기 취소 API 구현
- [x] 주식 즐겨찾기 리스트 조회 API 구현
- [x] 특정 종목에 대한 즐겨찾기 등록 여부 조회 API 구현

### 💭 고민과 해결과정
- 소켓 구독 리소스 아끼기 위해서 즐겨찾기 조회 시에 API로 현재가 가지고 오도록 구현했고, 소켓으로 실시간 가격을 보내주지는 않도록 했다.
- task에 있는 API 외에도 특정 종목 디테일 페이지 들어갔을 때 현재 즐겨찾기에 등록된 종목인지 확인하는 API가 있어야할 것 같아서 만들어두었다. (아래 이미지 하트 색칠 여부 결정)
![image](https://github.com/user-attachments/assets/2753d487-7aaf-4335-8910-e250c95eed04)
