### PR TITLE
[BE] 26.08 이동 평균선 계산 로직 추가 (#183)

### DIFF
--- a/BE/src/stock/detail/dto/stock-detail-chart-data.dto.ts
+++ b/BE/src/stock/detail/dto/stock-detail-chart-data.dto.ts
@@ -21,4 +21,10 @@ export class InquirePriceChartDataDto {
 
   @ApiProperty({ description: '전일 대비 부호' })
   prdy_vrss_sign: string;
+
+  @ApiProperty({ description: '이동 평균선 데이터(5일)' })
+  mov_avg_5: string;
+
+  @ApiProperty({ description: '이동 평균선 데이터(20일)' })
+  mov_avg_20: string;
 }

--- a/BE/src/stock/detail/stock-detail.service.ts
+++ b/BE/src/stock/detail/stock-detail.service.ts
@@ -85,7 +85,7 @@ export class StockDetailService {
     if (date1 === '') {
       const today = new Date();
       const pervDay = new Date();
-      pervDay.setDate(today.getDate() - 150);
+      pervDay.setDate(today.getDate() - 365);
       date2 = new Date().toISOString().slice(0, 10).replace(/-/g, '');
       date1 = pervDay.toISOString().slice(0, 10).replace(/-/g, '');
     }


### PR DESCRIPTION
### ✅ 주요 작업
- #183 
### 💭 고민과 해결과정
``` javascript
    if (date1 === '') {
      const today = new Date();
      const prevDay = new Date();
      prevDay.setDate(today.getDate() - 365);
      date2 = new Date().toISOString().slice(0, 10).replace(/-/g, '');
      date1 = prevDay.toISOString().slice(0, 10).replace(/-/g, '');
    }
```

평균선을 계산하기 위해선 기존에 30개만 가져오던 데이터에서 일별 차트의 경우 최소 5일 최대 20의 데이터를 더 가져와야 했습니다. 
이를 위해선 처음에 prevDay를 50일로 설정했으나 주식의 경우 주말, 공휴일 데이터가 없기 때문에 50일 전이라 해도 그보다 적은 데이터를 반환하는 현상이 발생함에 따라 임시로 1년 전까지를 요청함으로서 최대한 가져올 수 있는 데이터를 모두 가져오게 date설정을 바꿔 놓았습니다.

