### PR TITLE
[BE] 즐겨찾기, 마이페이지 API 수정

### DIFF
--- a/BE/src/asset/asset.entity.ts
+++ b/BE/src/asset/asset.entity.ts
@@ -22,7 +22,7 @@ export class Asset {
   @Column({ nullable: false, default: 0 })
   total_profit: number;
 
-  @Column('decimal', { nullable: false, default: 0, precision: 10, scale: 5 })
+  @Column('decimal', { nullable: false, default: 0, precision: 10, scale: 2 })
   total_profit_rate: number;
 
   @Column({ nullable: true })

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { MoreThan } from 'typeorm';
 import { UserStockRepository } from './user-stock.repository';
 import { AssetRepository } from './asset.repository';
 import { MypageResponseDto } from './dto/mypage-response.dto';
@@ -106,7 +107,7 @@ export class AssetService {
   private async updateMyAsset(asset: Asset, currPrices) {
     const userId = asset.user_id;
     const userStocks = await this.userStockRepository.find({
-      where: { user_id: userId },
+      where: { user_id: userId, quantity: MoreThan(0) },
     });
 
     const totalPrice = userStocks.reduce(

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -82,7 +82,7 @@ export class AssetService {
       newAsset.stock_balance,
       newAsset.total_asset,
       newAsset.total_profit,
-      newAsset.total_profit_rate,
+      newAsset.total_profit_rate.toFixed(2),
       newAsset.total_profit_rate >= 0,
     );
 

--- a/BE/src/asset/user-stock.entity.ts
+++ b/BE/src/asset/user-stock.entity.ts
@@ -21,7 +21,7 @@ export class UserStock {
   @Column({ nullable: false })
   quantity: number;
 
-  @Column('float', { nullable: false, scale: 5 })
+  @Column('float', { nullable: false, scale: 2 })
   avg_price: number;
 
   @UpdateDateColumn()

--- a/BE/src/asset/user-stock.repository.ts
+++ b/BE/src/asset/user-stock.repository.ts
@@ -17,7 +17,9 @@ export class UserStockRepository extends Repository<UserStock> {
         'stocks',
         'stocks.code = user_stocks.stock_code',
       )
-      .where('user_stocks.user_id = :userId', { userId })
+      .where('user_stocks.user_id = :userId AND user_stocks.quantity > 0', {
+        userId,
+      })
       .getRawMany<UserStockInterface>();
   }
 

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -13,10 +13,10 @@ async function bootstrap() {
       'http://localhost:5173',
       'http://juga.kro.kr:5173',
       'http://juga.kro.kr:3000',
-      //개발 서버
+      // 개발 서버
       'http://223.130.151.42:5173',
       'http://223.130.151.42:3000',
-      //배포 서버
+      // 배포 서버
       'http://175.45.204.158',
       'http://175.45.204.158:3000',
       'http://juga.kro.kr',

--- a/BE/src/ranking/ranking.service.ts
+++ b/BE/src/ranking/ranking.service.ts
@@ -98,7 +98,7 @@ export class RankingService {
 
     return {
       topRank: parsedTopRank,
-      userRank: userRank,
+      userRank,
     };
   }
 

--- a/BE/src/stock/bookmark/stock-bookmark.controller.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.controller.ts
@@ -73,23 +73,4 @@ export class StockBookmarkController {
       parseInt(request.user.userId, 10),
     );
   }
-
-  @Get('/:stockCode')
-  @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: '특정 종목에 대한 즐겨찾기 등록 여부 조회 API' })
-  @ApiResponse({
-    status: 200,
-    description: '즐겨찾기 등록 여부 조회 성공',
-    example: { is_bookmarked: true },
-  })
-  async getBookmarkActive(
-    @Req() request: Request,
-    @Param('stockCode') stockCode: string,
-  ) {
-    return this.stockBookmarkService.getBookmarkActive(
-      parseInt(request.user.userId, 10),
-      stockCode,
-    );
-  }
 }

--- a/BE/src/stock/bookmark/stock-bookmark.service.ts
+++ b/BE/src/stock/bookmark/stock-bookmark.service.ts
@@ -62,13 +62,4 @@ export class StockBookmarkService {
       }),
     );
   }
-
-  async getBookmarkActive(userId, stockCode) {
-    return {
-      is_bookmarked: await this.stockBookmarkRepository.existsBy({
-        user_id: userId,
-        stock_code: stockCode,
-      }),
-    };
-  }
 }

--- a/BE/src/stock/detail/dto/stock-detail-response.dto.ts
+++ b/BE/src/stock/detail/dto/stock-detail-response.dto.ts
@@ -30,4 +30,7 @@ export class InquirePriceResponseDto {
 
   @ApiProperty({ description: '주식 하한가' })
   stck_llam: string;
+
+  @ApiProperty({ description: '즐겨찾기 여부 (미인증시 false)' })
+  is_bookmarked: boolean;
 }

--- a/BE/src/stock/detail/stock-detail.controller.ts
+++ b/BE/src/stock/detail/stock-detail.controller.ts
@@ -1,15 +1,26 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
   ApiBody,
   ApiOperation,
   ApiParam,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
+import { Request } from 'express';
 import { StockDetailService } from './stock-detail.service';
 import { InquirePriceResponseDto } from './dto/stock-detail-response.dto';
 import { StockDetailChartRequestDto } from './dto/stock-detail-chart-request.dto';
 import { InquirePriceChartResponseDto } from './dto/stock-detail-chart-response.dto';
+import { OptionalAuthGuard } from '../../auth/optional-auth-guard';
 
 @ApiTags('특정 주식 종목에 대한 detail 페이지 조회 API')
 @Controller('/api/stocks/detail')
@@ -17,6 +28,8 @@ export class StockDetailController {
   constructor(private readonly stockDetailService: StockDetailService) {}
 
   @Get(':stockCode')
+  @ApiBearerAuth()
+  @UseGuards(OptionalAuthGuard)
   @ApiOperation({ summary: '단일 주식 종목 detail 페이지 상단부 조회 API' })
   @ApiParam({
     name: 'stockCode',
@@ -30,8 +43,18 @@ export class StockDetailController {
     description: '단일 주식 종목 기본값 조회 성공',
     type: InquirePriceResponseDto,
   })
-  getStockDetail(@Param('stockCode') stockCode: string) {
-    return this.stockDetailService.getInquirePrice(stockCode);
+  async getStockDetail(
+    @Req() request: Request,
+    @Param('stockCode') stockCode: string,
+  ) {
+    const stockData = await this.stockDetailService.getInquirePrice(stockCode);
+    if (!request.user) return stockData;
+
+    stockData.is_bookmarked = await this.stockDetailService.getBookmarkActive(
+      parseInt(request.user.userId, 10),
+      stockCode,
+    );
+    return stockData;
   }
 
   @Post(':stockCode')

--- a/BE/src/stock/detail/stock-detail.module.ts
+++ b/BE/src/stock/detail/stock-detail.module.ts
@@ -5,6 +5,7 @@ import { StockDetailController } from './stock-detail.controller';
 import { StockDetailService } from './stock-detail.service';
 import { StockDetailRepository } from './stock-detail.repository';
 import { Stocks } from './stock-detail.entity';
+import { StockBookmarkModule } from '../bookmark/stock-bookmark.module';
 
 @Module({
   imports: [KoreaInvestmentModule, TypeOrmModule.forFeature([Stocks])],

--- a/BE/src/stock/detail/stock-detail.module.ts
+++ b/BE/src/stock/detail/stock-detail.module.ts
@@ -5,7 +5,6 @@ import { StockDetailController } from './stock-detail.controller';
 import { StockDetailService } from './stock-detail.service';
 import { StockDetailRepository } from './stock-detail.repository';
 import { Stocks } from './stock-detail.entity';
-import { StockBookmarkModule } from '../bookmark/stock-bookmark.module';
 
 @Module({
   imports: [KoreaInvestmentModule, TypeOrmModule.forFeature([Stocks])],

--- a/BE/src/stock/detail/stock-detail.repository.ts
+++ b/BE/src/stock/detail/stock-detail.repository.ts
@@ -2,14 +2,23 @@ import { InjectDataSource } from '@nestjs/typeorm';
 import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { Stocks } from './stock-detail.entity';
+import { Bookmark } from '../bookmark/stock-bookmark.entity';
 
 @Injectable()
 export class StockDetailRepository extends Repository<Stocks> {
-  constructor(@InjectDataSource() dataSource: DataSource) {
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {
     super(Stocks, dataSource.createEntityManager());
   }
 
   async findOneByCode(code: string) {
     return this.findOne({ where: { code } });
+  }
+
+  async existsBookmarkByUserIdAndStockCode(userId: number, stockCode: string) {
+    const queryRunner = this.dataSource.createQueryRunner();
+    return queryRunner.manager.existsBy(Bookmark, {
+      user_id: userId,
+      stock_code: stockCode,
+    });
   }
 }

--- a/BE/src/stock/detail/stock-detail.repository.ts
+++ b/BE/src/stock/detail/stock-detail.repository.ts
@@ -16,9 +16,21 @@ export class StockDetailRepository extends Repository<Stocks> {
 
   async existsBookmarkByUserIdAndStockCode(userId: number, stockCode: string) {
     const queryRunner = this.dataSource.createQueryRunner();
-    return queryRunner.manager.existsBy(Bookmark, {
-      user_id: userId,
-      stock_code: stockCode,
-    });
+    await queryRunner.startTransaction();
+
+    try {
+      const isExist = queryRunner.manager.existsBy(Bookmark, {
+        user_id: userId,
+        stock_code: stockCode,
+      });
+
+      await queryRunner.commitTransaction();
+      return await isExist;
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
   }
 }

--- a/BE/src/stock/detail/stock-detail.service.ts
+++ b/BE/src/stock/detail/stock-detail.service.ts
@@ -63,6 +63,7 @@ export class StockDetailService {
       per: stock.per,
       stck_mxpr: stock.stck_mxpr,
       stck_llam: stock.stck_llam,
+      is_bookmarked: false,
     };
   }
 
@@ -99,6 +100,13 @@ export class StockDetailService {
       );
 
     return this.formatStockInquirePriceData(response).slice().reverse();
+  }
+
+  getBookmarkActive(userId: number, stockCode: string) {
+    return this.stockDetailRepository.existsBookmarkByUserIdAndStockCode(
+      userId,
+      stockCode,
+    );
   }
 
   /**


### PR DESCRIPTION
### ✅ 주요 작업
- [x] 즐겨찾기 여부 조회 API를 detail 페이지 상단부 조회 API와 통합 (조회할 때 로그인 안되어있으면 기본값 false)
- [x] 마이페이지 API 보유량이 0인 종목은 조회하지 않도록 수정
- [x] 마이페이지 수익률 소수점 2자리로 고정
- [x] queryRunner 사용 부분에 트랜잭션 추가 (이전 작업 반영되어야 하는 커밋이라서 어쩔 수 없이 여기 이어서 올렸습니다ㅠㅠ)
