### PR TITLE
[FE] 즐겨찾기 관련 레이아웃 구현 및 API 연동

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^18.3.1",
         "react-error-boundary": "^4.1.2",
         "react-router-dom": "^6.27.0",
+        "react-toastify": "^10.0.6",
         "socket.io-client": "^4.8.1",
         "vite-tsconfig-paths": "^5.0.1",
         "zustand": "^5.0.1"
@@ -1924,6 +1925,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3484,6 +3493,18 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
+      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {

--- a/FE/package.json
+++ b/FE/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.1.2",
     "react-router-dom": "^6.27.0",
+    "react-toastify": "^10.0.6",
     "socket.io-client": "^4.8.1",
     "vite-tsconfig-paths": "^5.0.1",
     "zustand": "^5.0.1"

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -12,6 +12,8 @@ import Login from 'components/Login';
 import SearchModal from './components/Search';
 import MyPage from 'page/MyPage';
 import Rank from 'page/Rank.tsx';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 function App() {
   return (
@@ -39,6 +41,7 @@ function Layout() {
       </main>
       <Login />
       <SearchModal />
+      <ToastContainer />
     </>
   );
 }

--- a/FE/src/components/Mypage/Account.tsx
+++ b/FE/src/components/Mypage/Account.tsx
@@ -20,8 +20,6 @@ export default function Account() {
 
   const { asset, stocks } = data;
 
-  console.log(asset, stocks);
-
   return (
     <div className='flex min-h-[500px] flex-col gap-3'>
       <AccountCondition asset={asset} />

--- a/FE/src/components/Mypage/BookMark.tsx
+++ b/FE/src/components/Mypage/BookMark.tsx
@@ -1,0 +1,73 @@
+import { useNavigate } from 'react-router-dom';
+
+const stocks = [
+  {
+    name: '삼성전자',
+    code: '005930',
+    stck_prpr: '50000',
+    prdy_vrss: '3.5',
+    prdy_vrss_sign: '3',
+    prdy_ctrt: '123',
+  },
+  {
+    name: '삼성전자',
+    code: '005930',
+    stck_prpr: '50000',
+    prdy_vrss: '3.5',
+    prdy_vrss_sign: '3',
+    prdy_ctrt: '123',
+  },
+  {
+    name: '삼성전자',
+    code: '005930',
+    stck_prpr: '50000',
+    prdy_vrss: '3.5',
+    prdy_vrss_sign: '3',
+    prdy_ctrt: '123',
+  },
+];
+
+export default function BookMark() {
+  const navigation = useNavigate();
+
+  const handleClick = (code: string) => {
+    navigation(`/stocks/${code}`);
+  };
+
+  return (
+    <div className='mx-auto flex min-h-[500px] w-full flex-1 flex-col rounded-md bg-white p-4 shadow-md'>
+      <div className='flex pb-2 text-sm font-bold border-b'>
+        <p className='w-1/2 text-left truncate'>종목</p>
+        <p className='w-1/4 text-center'>현재가</p>
+        <p className='w-1/4 text-right'>등락률</p>
+      </div>
+
+      <ul className='flex flex-col text-sm divide-y'>
+        {stocks.map((stock) => {
+          const { code, name, stck_prpr, prdy_ctrt, prdy_vrss_sign } = stock;
+
+          return (
+            <li
+              className='flex py-2 transition-colors hover:cursor-pointer hover:bg-gray-50'
+              key={code}
+              onClick={() => handleClick(code)}
+            >
+              <div className='flex w-1/2 gap-2 text-left truncate'>
+                <p className='font-semibold'>{name}</p>
+                <p className='text-gray-500'>{code}</p>
+              </div>
+              <p className='w-1/4 text-center truncate'>
+                {(+stck_prpr).toLocaleString()}원
+              </p>
+              <p
+                className={`w-1/4 truncate text-right ${+prdy_vrss_sign < 3 ? 'text-juga-blue-50' : 'text-juga-red-60'}`}
+              >
+                {prdy_ctrt}%
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/FE/src/components/Mypage/BookMark.tsx
+++ b/FE/src/components/Mypage/BookMark.tsx
@@ -1,31 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-
-const stocks = [
-  {
-    name: '삼성전자',
-    code: '005930',
-    stck_prpr: '50000',
-    prdy_vrss: '3.5',
-    prdy_vrss_sign: '3',
-    prdy_ctrt: '123',
-  },
-  {
-    name: '삼성전자',
-    code: '005930',
-    stck_prpr: '50000',
-    prdy_vrss: '3.5',
-    prdy_vrss_sign: '3',
-    prdy_ctrt: '123',
-  },
-  {
-    name: '삼성전자',
-    code: '005930',
-    stck_prpr: '50000',
-    prdy_vrss: '3.5',
-    prdy_vrss_sign: '3',
-    prdy_ctrt: '123',
-  },
-];
+import { getBookmarkedStocks } from 'service/bookmark';
 
 export default function BookMark() {
   const navigation = useNavigate();
@@ -33,6 +8,18 @@ export default function BookMark() {
   const handleClick = (code: string) => {
     navigation(`/stocks/${code}`);
   };
+
+  const { data, isLoading, isError } = useQuery(
+    ['bookmark', 'stock'],
+    () => getBookmarkedStocks(),
+    {
+      staleTime: 1000,
+    },
+  );
+
+  if (isLoading) return <div>loading</div>;
+  if (!data) return <div>No data</div>;
+  if (isError) return <div>error</div>;
 
   return (
     <div className='mx-auto flex min-h-[500px] w-full flex-1 flex-col rounded-md bg-white p-4 shadow-md'>
@@ -43,7 +30,7 @@ export default function BookMark() {
       </div>
 
       <ul className='flex flex-col text-sm divide-y'>
-        {stocks.map((stock) => {
+        {data.map((stock) => {
           const { code, name, stck_prpr, prdy_ctrt, prdy_vrss_sign } = stock;
 
           return (
@@ -60,7 +47,7 @@ export default function BookMark() {
                 {(+stck_prpr).toLocaleString()}원
               </p>
               <p
-                className={`w-1/4 truncate text-right ${+prdy_vrss_sign < 3 ? 'text-juga-blue-50' : 'text-juga-red-60'}`}
+                className={`w-1/4 truncate text-right ${+prdy_vrss_sign > 3 ? 'text-juga-blue-50' : 'text-juga-red-60'}`}
               >
                 {prdy_ctrt}%
               </p>

--- a/FE/src/components/Mypage/Nav.tsx
+++ b/FE/src/components/Mypage/Nav.tsx
@@ -4,9 +4,10 @@ import { MypageSectionType } from 'types';
 const mapping = {
   account: '보유 자산 현황',
   order: '주문 요청 현황',
+  bookmark: '즐겨찾기',
   info: '내 정보',
 };
-const sections: MypageSectionType[] = ['account', 'order', 'info'];
+const sections: MypageSectionType[] = ['account', 'order', 'bookmark', 'info'];
 
 export default function Nav() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/FE/src/components/Search/index.tsx
+++ b/FE/src/components/Search/index.tsx
@@ -70,8 +70,18 @@ export default function SearchModal() {
 
               <div className={'h-[400px] overflow-y-auto'}>
                 {isSearching ? (
-                  <div className={'flex h-full items-center justify-center'}>
-                    <Lottie animationData={searchAnimation} />
+                  <div
+                    className={
+                      'flex h-[320px] flex-col items-center justify-center'
+                    }
+                  >
+                    <Lottie
+                      animationData={searchAnimation}
+                      className='h-[200px]'
+                    />
+                    <p className='font-bold text-juga-grayscale-black'>
+                      두 글자 이상의 검색어를 입력해주세요.
+                    </p>
                   </div>
                 ) : (
                   showSearchResults && <SearchList searchData={data} />

--- a/FE/src/components/StocksDetail/Header.tsx
+++ b/FE/src/components/StocksDetail/Header.tsx
@@ -1,6 +1,6 @@
 import { HeartIcon } from '@heroicons/react/16/solid';
 import Toast from 'components/Toast';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { bookmark, unbookmark } from 'service/bookmark';
 import { unsubscribe } from 'service/stocks';
 import useAuthStore from 'store/authStore';
@@ -8,7 +8,7 @@ import useLoginModalStore from 'store/useLoginModalStore';
 import { StockDetailType } from 'types';
 import { stringToLocaleString } from 'utils/common';
 import { socket } from 'utils/socket';
-import { useDebounce } from 'utils/useDebounce';
+// import { useDebounce } from 'utils/useDebounce';
 
 type StocksDetailHeaderProps = {
   code: string;
@@ -35,21 +35,21 @@ export default function Header({ code, data }: StocksDetailHeaderProps) {
   const { isLogin } = useAuthStore();
   const { toggleModal } = useLoginModalStore();
 
-  const { debounceValue } = useDebounce(isBookmarked, 1000);
-  const isInitialMount = useRef(true);
+  // const { debounceValue } = useDebounce(isBookmarked, 1000);
+  // const isInitialMount = useRef(true);
 
-  useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      return;
-    }
+  // useEffect(() => {
+  //   if (isInitialMount.current) {
+  //     isInitialMount.current = false;
+  //     return;
+  //   }
 
-    if (debounceValue) {
-      bookmark(code);
-    } else {
-      unbookmark(code);
-    }
-  }, [code, debounceValue]);
+  //   if (debounceValue) {
+  //     bookmark(code);
+  //   } else {
+  //     unbookmark(code);
+  //   }
+  // }, [code, debounceValue]);
 
   useEffect(() => {
     const handleSocketData = (data: {
@@ -121,6 +121,9 @@ export default function Header({ code, data }: StocksDetailHeaderProps) {
               Toast({ message: '로그인을 해주세요!', type: 'warning' });
               return;
             }
+            if (isBookmarked) unbookmark(code);
+            else bookmark(code);
+
             setIsBookmarked((prev) => !prev);
           }}
         >

--- a/FE/src/components/StocksDetail/Header.tsx
+++ b/FE/src/components/StocksDetail/Header.tsx
@@ -1,8 +1,10 @@
 import { HeartIcon } from '@heroicons/react/16/solid';
+import Toast from 'components/Toast';
 import { useEffect, useRef, useState } from 'react';
 import { bookmark, unbookmark } from 'service/bookmark';
 import { unsubscribe } from 'service/stocks';
 import useAuthStore from 'store/authStore';
+import useLoginModalStore from 'store/useLoginModalStore';
 import { StockDetailType } from 'types';
 import { stringToLocaleString } from 'utils/common';
 import { socket } from 'utils/socket';
@@ -31,6 +33,7 @@ export default function Header({ code, data }: StocksDetailHeaderProps) {
   const [currPrdyRate, setCurrPrdyRate] = useState(prdy_ctrt);
   const [isBookmarked, setIsBookmarked] = useState(is_bookmarked);
   const { isLogin } = useAuthStore();
+  const { toggleModal } = useLoginModalStore();
 
   const { debounceValue } = useDebounce(isBookmarked, 1000);
   const isInitialMount = useRef(true);
@@ -114,6 +117,8 @@ export default function Header({ code, data }: StocksDetailHeaderProps) {
         <button
           onClick={() => {
             if (!isLogin) {
+              toggleModal();
+              Toast({ message: '로그인을 해주세요!', type: 'warning' });
               return;
             }
             setIsBookmarked((prev) => !prev);

--- a/FE/src/components/StocksDetail/Header.tsx
+++ b/FE/src/components/StocksDetail/Header.tsx
@@ -1,3 +1,4 @@
+import { HeartIcon } from '@heroicons/react/16/solid';
 import { useEffect, useState } from 'react';
 import { unsubscribe } from 'service/stocks';
 import { StockDetailType } from 'types';
@@ -18,12 +19,14 @@ export default function Header({ code, data }: StocksDetailHeaderProps) {
     prdy_ctrt,
     hts_avls,
     per,
+    is_bookmarked,
   } = data;
 
   const [currPrice, setCurrPrice] = useState(stck_prpr);
   const [currPrdyVrssSign, setCurrPrdyVrssSign] = useState(prdy_vrss_sign);
   const [currPrdyVrss, setCurrPrdyVrss] = useState(prdy_vrss);
   const [currPrdyRate, setCurrPrdyRate] = useState(prdy_ctrt);
+  const [isBookmarked, setIsBookmarked] = useState(is_bookmarked);
 
   useEffect(() => {
     const handleSocketData = (data: {
@@ -65,7 +68,7 @@ export default function Header({ code, data }: StocksDetailHeaderProps) {
     currPrdyVrssSign === '3' ? '' : currPrdyVrssSign < '3' ? '+' : '-';
 
   return (
-    <div className='flex h-16 w-full items-center justify-between px-2'>
+    <div className='flex items-center justify-between w-full h-16 px-2'>
       <div className='flex flex-col font-semibold'>
         <div className='flex gap-2 text-sm'>
           <h2>{hts_kor_isnm}</h2>
@@ -81,13 +84,20 @@ export default function Header({ code, data }: StocksDetailHeaderProps) {
           </p>
         </div>
       </div>
-      <div className='flex gap-4 text-xs font-semibold'>
+      <div className='flex items-center gap-4 text-xs font-semibold'>
         {stockInfo.map((e, idx) => (
           <div key={`stockdetailinfo${idx}`} className='flex gap-2'>
             <p className='text-juga-grayscale-200'>{e.label}</p>
             <p>{e.value}</p>
           </div>
         ))}
+        <button onClick={() => setIsBookmarked((prev) => !prev)}>
+          {isBookmarked ? (
+            <HeartIcon className='size-6 fill-juga-red-60' />
+          ) : (
+            <HeartIcon className='size-6 fill-juga-grayscale-200' />
+          )}
+        </button>
       </div>
     </div>
   );

--- a/FE/src/components/Toast.tsx
+++ b/FE/src/components/Toast.tsx
@@ -1,0 +1,23 @@
+import { toast } from 'react-toastify';
+
+type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+type ToastProps = {
+  message: string;
+  type: ToastType;
+};
+
+export default function Toast({ message, type }: ToastProps) {
+  switch (type) {
+    case 'success':
+      return toast.success(message, { position: 'top-right', autoClose: 1000 });
+    case 'error':
+      return toast.error(message, { position: 'top-right', autoClose: 1000 });
+    case 'warning':
+      return toast.warning(message, { position: 'top-right', autoClose: 1000 });
+    case 'info':
+      return toast.info(message, { position: 'top-right', autoClose: 1000 });
+    default:
+      return null;
+  }
+}

--- a/FE/src/page/MyPage.tsx
+++ b/FE/src/page/MyPage.tsx
@@ -1,4 +1,5 @@
 import Account from 'components/Mypage/Account';
+import BookMark from 'components/Mypage/BookMark';
 import MyInfo from 'components/Mypage/MyInfo';
 import Nav from 'components/Mypage/Nav';
 import Order from 'components/Mypage/Order';
@@ -16,6 +17,7 @@ export default function MyPage() {
           {
             account: <Account />,
             order: <Order />,
+            bookmark: <BookMark />,
             info: <MyInfo />,
           }[currentPage]
         }

--- a/FE/src/service/bookmark.ts
+++ b/FE/src/service/bookmark.ts
@@ -1,0 +1,27 @@
+export async function bookmark(code: string) {
+  const url = import.meta.env.PROD
+    ? `${import.meta.env.VITE_API_URL}/stocks/bookmark/${code}`
+    : `/api/stocks/bookmark/${code}`;
+
+  return fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+export async function unbookmark(code: string) {
+  const url = import.meta.env.PROD
+    ? `${import.meta.env.VITE_API_URL}/stocks/bookmark/${code}`
+    : `/api/stocks/bookmark/${code}`;
+
+  return fetch(url, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/FE/src/service/bookmark.ts
+++ b/FE/src/service/bookmark.ts
@@ -1,3 +1,5 @@
+import { BookmakredStock } from 'types';
+
 export async function bookmark(code: string) {
   const url = import.meta.env.PROD
     ? `${import.meta.env.VITE_API_URL}/stocks/bookmark/${code}`
@@ -24,4 +26,17 @@ export async function unbookmark(code: string) {
       'Content-Type': 'application/json',
     },
   });
+}
+
+export async function getBookmarkedStocks(): Promise<BookmakredStock[]> {
+  const url = import.meta.env.PROD
+    ? `${import.meta.env.VITE_API_URL}/stocks/bookmark`
+    : '/api/stocks/bookmark';
+
+  return fetch(url, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then((res) => res.json());
 }

--- a/FE/src/types.ts
+++ b/FE/src/types.ts
@@ -28,6 +28,7 @@ export type StockDetailType = {
   per: string;
   stck_mxpr: string;
   stck_llam: string;
+  is_bookmarked: boolean;
 };
 
 export type StockChartUnit = {

--- a/FE/src/types.ts
+++ b/FE/src/types.ts
@@ -92,3 +92,12 @@ export type Profile = {
   name: string;
   email: string;
 };
+
+export type BookmakredStock = {
+  name: string;
+  code: string;
+  stck_prpr: string;
+  prdy_vrss: string;
+  prdy_vrss_sign: string;
+  prdy_ctrt: string;
+};

--- a/FE/src/types.ts
+++ b/FE/src/types.ts
@@ -43,7 +43,7 @@ export type StockChartUnit = {
   mov_avg_20?: string;
 };
 
-export type MypageSectionType = 'account' | 'order' | 'info';
+export type MypageSectionType = 'account' | 'order' | 'bookmark' | 'info';
 
 export type Asset = {
   cash_balance: string;

--- a/FE/src/utils/useDebounce.ts
+++ b/FE/src/utils/useDebounce.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import { formatNoSpecialChar } from './formatNoSpecialChar.ts';
 
-export const useDebounce = (value: string, delay: number) => {
+export const useDebounce = <T>(value: T, delay: number) => {
   const [debounceValue, setDebounceValue] = useState(value);
   const [isDebouncing, setIsDebouncing] = useState(false);
 
@@ -9,7 +8,7 @@ export const useDebounce = (value: string, delay: number) => {
     setIsDebouncing(true);
 
     const handler = setTimeout(() => {
-      setDebounceValue(formatNoSpecialChar(value));
+      setDebounceValue(value);
       setIsDebouncing(false);
     }, delay);
 


### PR DESCRIPTION
### ✅ 주요 작업
- 즐겨찾기 관련 레이아웃 구현 및 API 연동
  - 즐겨찾기 등록
  - 즐겨찾기 취소
  - 즐겨찾기 목록 조회   
- toastify 설정

![image](https://github.com/user-attachments/assets/28b6116f-f45b-490f-9b13-ac70ae7c14fd)

![image](https://github.com/user-attachments/assets/69fc6f51-5fdf-4837-bccf-5dc39b7503c8)


### 💭 고민과 해결과정
즐겨찾기 등록, 취소할 때 디바운스를 걸어 연속적인 호출을 하지 못하게 하려고 했다.
그래서 useEffect로 debouncedValue에 변화를 측정해 구현하려고 했지만 페이지가 렌더링될 때마다 즐겨찾기 취소가 되는 문제가 있었다.
명확한 이유를 찾지 못해 일단 즐겨찾기를 클릭할 때마다 등록/취소 api가 호출되도록 변경했다.
추후에 문제가 발생한 원인이 어떤 것인지 한 번 분석해봐야겠다.


close #212 #213 #214 #215 #216 #217 
