### PR TITLE
[BE] 회원가입시 기본 닉네임 설정

### DIFF
--- a/BE/src/auth/user.repository.ts
+++ b/BE/src/auth/user.repository.ts
@@ -26,6 +26,10 @@ export class UserRepository extends Repository<User> {
       const hashedPassword: string = await bcrypt.hash(password, salt);
       const user = this.create({ email, password: hashedPassword });
       await queryRunner.manager.save(user);
+
+      user.nickname = `익명의 투자자${user.id}`;
+      await queryRunner.manager.save(user);
+
       const asset = this.assetRepository.create({ user_id: user.id });
       await queryRunner.manager.save(asset);
 
@@ -52,6 +56,10 @@ export class UserRepository extends Repository<User> {
         password: hashedPassword,
       });
       await this.save(user);
+
+      user.nickname = `익명의 투자자${user.id}`;
+      await queryRunner.manager.save(user);
+
       const asset = this.assetRepository.create({ user_id: user.id });
       await queryRunner.manager.save(asset);
 

--- a/BE/src/auth/user.service.ts
+++ b/BE/src/auth/user.service.ts
@@ -21,6 +21,10 @@ export class UserService {
       throw new NotFoundException('존재하지 않는 유저입니다.');
     }
 
+    if (newName.replaceAll(/ /g, '').includes('익명의투자자')) {
+      throw new BadRequestException('사용 불가능한 문자가 포함되어 있습니다.');
+    }
+
     const isDuplicated = await this.userRepository.findBy({
       nickname: newName,
     });


### PR DESCRIPTION
### ✅ 주요 작업
- 회원가입시 자동으로 '익명의 투자자' + userId 번호로 닉네임 설정
- 닉네임 변경할 때 기본 닉네임인 '익명의 투자자'가 포함된 닉네임으로 변경되지 않게 로직 추가

### 💭 고민과 해결과정
- 사실 제 독단으로 추가한 부분이라 내일 이야기해보긴 해야 합니다..ㅎㅎ
- 나중에 정규식이나 사용 불가능한 단어(게임에서 필터링되는 단어같은..!)도 닉네임 설정 때 못쓰게 해야 할 거 같긴 합니다.
