### PR TITLE
[FE] 유저 닉네임 수정 레이아웃 구현 및 API 연동

### DIFF
--- a/FE/src/components/Mypage/BookMark.tsx
+++ b/FE/src/components/Mypage/BookMark.tsx
@@ -49,6 +49,7 @@ export default function BookMark() {
               <p
                 className={`w-1/4 truncate text-right ${+prdy_vrss_sign > 3 ? 'text-juga-blue-50' : 'text-juga-red-60'}`}
               >
+                {+prdy_vrss_sign < 3 && '+'}
                 {prdy_ctrt}%
               </p>
             </li>

--- a/FE/src/components/Mypage/MyInfo.tsx
+++ b/FE/src/components/Mypage/MyInfo.tsx
@@ -1,16 +1,14 @@
 import { PencilSquareIcon } from '@heroicons/react/16/solid';
-import { useQuery } from '@tanstack/react-query';
 import Toast from 'components/Toast';
+
+import useUser from 'hooks/useUser';
 import { useEffect, useState } from 'react';
-import { getMyProfile, rename } from 'service/user';
 
 export default function MyInfo() {
   const [isEditMode, setIsEditMode] = useState(false);
-  const { data, isLoading, isError } = useQuery(
-    ['myInfo', 'profile'],
-    () => getMyProfile(),
-    { staleTime: 1000 },
-  );
+  const { userQuery, updateNickame } = useUser();
+
+  const { data, isLoading, isError } = userQuery;
 
   const [nickname, setNickname] = useState('');
 
@@ -29,12 +27,14 @@ export default function MyInfo() {
       return;
     }
 
-    rename(nickname).then((res) => {
-      if (res.statusCode === 400) {
-        Toast({ message: res.message, type: 'error' });
-        return;
-      }
-      setIsEditMode(false);
+    updateNickame.mutate(nickname, {
+      onSuccess: (res) => {
+        if (res.statusCode === 400) {
+          Toast({ message: res.message, type: 'error' });
+          return;
+        }
+        setIsEditMode(false);
+      },
     });
   };
 

--- a/FE/src/components/Mypage/MyInfo.tsx
+++ b/FE/src/components/Mypage/MyInfo.tsx
@@ -1,7 +1,8 @@
 import { PencilSquareIcon } from '@heroicons/react/16/solid';
 import { useQuery } from '@tanstack/react-query';
+import Toast from 'components/Toast';
 import { useEffect, useState } from 'react';
-import { getMyProfile } from 'service/user';
+import { getMyProfile, rename } from 'service/user';
 
 export default function MyInfo() {
   const [isEditMode, setIsEditMode] = useState(false);
@@ -22,6 +23,16 @@ export default function MyInfo() {
   if (!data) return <div>No data</div>;
   if (isError) return <div>error</div>;
 
+  const handeleEditBtnClick = () => {
+    rename(nickname).then((res) => {
+      if (res.statusCode === 400) {
+        Toast({ message: res.message, type: 'error' });
+        return;
+      }
+      setIsEditMode(false);
+    });
+  };
+
   return (
     <div className='flex flex-col items-center p-6 text-lg'>
       <div className='flex w-[50%] items-center gap-2 py-2'>
@@ -40,7 +51,7 @@ export default function MyInfo() {
                   autoFocus
                 />
                 <button
-                  onClick={() => setIsEditMode(false)}
+                  onClick={handeleEditBtnClick}
                   className='w-10 p-1 text-sm font-semibold text-white rounded-lg bg-juga-blue-40'
                 >
                   수정

--- a/FE/src/components/Mypage/MyInfo.tsx
+++ b/FE/src/components/Mypage/MyInfo.tsx
@@ -1,34 +1,63 @@
 import { PencilSquareIcon } from '@heroicons/react/16/solid';
 import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
 import { getMyProfile } from 'service/user';
 
 export default function MyInfo() {
+  const [isEditMode, setIsEditMode] = useState(false);
   const { data, isLoading, isError } = useQuery(
     ['myInfo', 'profile'],
     () => getMyProfile(),
     { staleTime: 1000 },
   );
 
+  const [nickname, setNickname] = useState('');
+
+  useEffect(() => {
+    if (!data) return;
+    setNickname(data.name);
+  }, [data]);
+
   if (isLoading) return <div>loading</div>;
   if (!data) return <div>No data</div>;
   if (isError) return <div>error</div>;
-
-  const { name } = data;
 
   return (
     <div className='flex flex-col items-center p-6 text-lg'>
       <div className='flex w-[50%] items-center gap-2 py-2'>
         <div className='flex items-center justify-between w-full'>
           <p className='w-28 min-w-[100px] truncate font-medium text-juga-grayscale-black'>
-            username
+            닉네임
           </p>
           <div className='flex items-center gap-2'>
-            <p className='min-w-[50px] truncate font-semibold text-juga-grayscale-500'>
-              {name}
-            </p>
-            <button>
-              <PencilSquareIcon className='w-5 h-5' />
-            </button>
+            {isEditMode ? (
+              <>
+                <input
+                  type='text'
+                  value={nickname}
+                  onChange={(e) => setNickname(e.target.value)}
+                  className='min-w-[50px] text-right font-semibold text-juga-grayscale-500'
+                  autoFocus
+                />
+                <button
+                  onClick={() => setIsEditMode(false)}
+                  className='w-10 p-1 text-sm font-semibold text-white rounded-lg bg-juga-blue-40'
+                >
+                  수정
+                </button>
+              </>
+            ) : (
+              <>
+                <p className='min-w-[50px] truncate font-semibold text-juga-grayscale-500'>
+                  {nickname}
+                </p>
+                <div className='flex items-center justify-end w-9'>
+                  <button onClick={() => setIsEditMode(true)}>
+                    <PencilSquareIcon className='w-5 h-5' />
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/FE/src/components/Mypage/MyInfo.tsx
+++ b/FE/src/components/Mypage/MyInfo.tsx
@@ -24,6 +24,11 @@ export default function MyInfo() {
   if (isError) return <div>error</div>;
 
   const handeleEditBtnClick = () => {
+    if (nickname === data.name) {
+      setIsEditMode(false);
+      return;
+    }
+
     rename(nickname).then((res) => {
       if (res.statusCode === 400) {
         Toast({ message: res.message, type: 'error' });

--- a/FE/src/components/Mypage/MyInfo.tsx
+++ b/FE/src/components/Mypage/MyInfo.tsx
@@ -35,9 +35,9 @@ export default function MyInfo() {
 
   return (
     <div className='flex flex-col items-center p-6 text-lg'>
-      <div className='flex w-[50%] items-center gap-2 py-2'>
+      <div className='flex w-full max-w-[600px] items-center gap-2 py-2 sm:w-[80%] lg:w-[50%]'>
         <div className='flex items-center justify-between w-full'>
-          <p className='w-28 min-w-[100px] truncate font-medium text-juga-grayscale-black'>
+          <p className='w-28 min-w-[80px] truncate font-medium text-juga-grayscale-black sm:min-w-[100px]'>
             닉네임
           </p>
           <div className='flex items-center gap-2'>
@@ -47,7 +47,7 @@ export default function MyInfo() {
                   type='text'
                   value={nickname}
                   onChange={(e) => setNickname(e.target.value)}
-                  className='min-w-[50px] text-right font-semibold text-juga-grayscale-500'
+                  className='w-24 min-w-[60px] flex-1 text-right font-semibold text-juga-grayscale-500 sm:w-auto sm:min-w-[80px]'
                   autoFocus
                 />
                 <button
@@ -59,7 +59,7 @@ export default function MyInfo() {
               </>
             ) : (
               <>
-                <p className='min-w-[50px] truncate font-semibold text-juga-grayscale-500'>
+                <p className='min-w-[60px] truncate font-semibold text-juga-grayscale-500 sm:min-w-[80px]'>
                   {nickname}
                 </p>
                 <div className='flex items-center justify-end w-9'>

--- a/FE/src/components/Mypage/MyInfo.tsx
+++ b/FE/src/components/Mypage/MyInfo.tsx
@@ -61,6 +61,15 @@ export default function MyInfo() {
                 >
                   수정
                 </button>
+                <button
+                  onClick={() => {
+                    setNickname(data.name);
+                    setIsEditMode(false);
+                  }}
+                  className='w-10 p-1 text-sm font-semibold text-white rounded-lg bg-juga-grayscale-500'
+                >
+                  취소
+                </button>
               </>
             ) : (
               <>

--- a/FE/src/components/StocksDetail/TradeSection/BuySection.tsx
+++ b/FE/src/components/StocksDetail/TradeSection/BuySection.tsx
@@ -1,4 +1,11 @@
-import { ChangeEvent, FocusEvent, FormEvent, useRef, useState } from 'react';
+import {
+  ChangeEvent,
+  FocusEvent,
+  FormEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import useTradeAlertModalStore from 'store/tradeAlertModalStore';
 import { StockDetailType } from 'types';
 import { isNumericString } from 'utils/common';
@@ -23,6 +30,10 @@ export default function BuySection({ code, detailInfo }: BuySectionProps) {
 
   const [currPrice, setCurrPrice] = useState<string>(stck_prpr);
   const { isLogin } = useAuthStore();
+
+  useEffect(() => {
+    setCurrPrice(stck_prpr);
+  }, [stck_prpr]);
 
   const { isOpen, toggleModal } = useTradeAlertModalStore();
 

--- a/FE/src/components/StocksDetail/TradeSection/SellSection.tsx
+++ b/FE/src/components/StocksDetail/TradeSection/SellSection.tsx
@@ -2,7 +2,14 @@ import Lottie from 'lottie-react';
 import emptyAnimation from 'assets/emptyAnimation.json';
 import { useQuery } from '@tanstack/react-query';
 import { getSellInfo } from 'service/assets';
-import { ChangeEvent, FocusEvent, FormEvent, useRef, useState } from 'react';
+import {
+  ChangeEvent,
+  FocusEvent,
+  FormEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { StockDetailType } from 'types';
 import useAuthStore from 'store/authStore';
 import useTradeAlertModalStore from 'store/tradeAlertModalStore';
@@ -33,6 +40,10 @@ export default function SellSection({ code, detailInfo }: SellSectionProps) {
   const timerRef = useRef<number | null>(null);
 
   const { isOpen, toggleModal } = useTradeAlertModalStore();
+
+  useEffect(() => {
+    setCurrPrice(stck_prpr);
+  }, [stck_prpr]);
 
   if (isLoading) return <div>loading</div>;
   if (!data) return <div>No data</div>;

--- a/FE/src/hooks/useUser.ts
+++ b/FE/src/hooks/useUser.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { getMyProfile, rename } from 'service/user';
+
+export default function useUser() {
+  const queryClient = useQueryClient();
+
+  const userQuery = useQuery(['myInfo', 'profile'], () => getMyProfile(), {
+    staleTime: 1000,
+  });
+
+  const updateNickame = useMutation((nickname: string) => rename(nickname), {
+    onSuccess: () => queryClient.invalidateQueries(['myInfo', 'profile']),
+  });
+
+  return { userQuery, updateNickame };
+}

--- a/FE/src/service/stocks.ts
+++ b/FE/src/service/stocks.ts
@@ -1,9 +1,16 @@
 import { StockChartUnit, StockDetailType, TiemCategory } from 'types';
 
 export async function getStocksByCode(code: string): Promise<StockDetailType> {
-  return fetch(`${import.meta.env.VITE_API_URL}/stocks/detail/${code}`).then(
-    (res) => res.json(),
-  );
+  const url = import.meta.env.PROD
+    ? `${import.meta.env.VITE_API_URL}/stocks/detail/${code}`
+    : `/api/stocks/detail/${code}`;
+
+  return fetch(url, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then((res) => res.json());
 }
 
 export async function getStocksChartDataByCode(

--- a/FE/src/service/user.ts
+++ b/FE/src/service/user.ts
@@ -10,3 +10,18 @@ export async function getMyProfile(): Promise<Profile> {
     headers: { 'Content-Type': 'application/json' },
   }).then((res) => res.json());
 }
+
+export async function rename(nickname: string) {
+  const url = import.meta.env.PROD
+    ? `${import.meta.env.VITE_API_URL}/user/rename`
+    : '/api/user/rename';
+
+  return fetch(url, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      nickname,
+    }),
+  }).then((res) => res.json());
+}


### PR DESCRIPTION
### ✅ 주요 작업
- 유저 닉네임 수정 레이아웃 구현
- 유저 닉네임 수정 API 연동

### 💭 고민과 해결과정
유저 닉네임이 수정되었을 때 기존에 가져왔던 query 데이터가 업데이트 되지 않았다.
커스텀 훅으로 묶어서 닉네임 수정이 완료되었을 때 invaludateQueries를 보내 업데이트 해주었다.
```tsx

export default function useUser() {
  const queryClient = useQueryClient();

  const userQuery = useQuery(['myInfo', 'profile'], () => getMyProfile(), {
    staleTime: 1000,
  });

  const updateNickame = useMutation((nickname: string) => rename(nickname), {
    onSuccess: () => queryClient.invalidateQueries(['myInfo', 'profile']),
  });

  return { userQuery, updateNickame };
}

```

