### PR TITLE
[BE] 닉네임 유효성 검사 로직 추가

### DIFF
--- a/BE/src/auth/user.service.ts
+++ b/BE/src/auth/user.service.ts
@@ -21,23 +21,29 @@ export class UserService {
       throw new NotFoundException('존재하지 않는 유저입니다.');
     }
 
-    if (newName.replaceAll(/ /g, '').includes('익명의투자자')) {
-      throw new BadRequestException('사용 불가능한 문자가 포함되어 있습니다.');
-    }
+    this.validateName(newName);
+    await this.checkNameDuplicate(newName);
 
+    return this.userRepository.update({ id: userId }, { nickname: newName });
+  }
+
+  private validateName(nickname: string) {
     const regex = /^[가-힣a-zA-Z0-9]+$/;
-
-    if (!regex.test(newName)) {
+    if (!regex.test(nickname)) {
       throw new BadRequestException('한글, 영문, 숫자만 사용 가능합니다.');
     }
 
+    if (nickname.includes('익명의투자자')) {
+      throw new BadRequestException('사용 불가능한 단어가 포함되어 있습니다.');
+    }
+  }
+
+  private async checkNameDuplicate(nickname: string) {
     const isDuplicated = await this.userRepository.existsBy({
-      nickname: newName,
+      nickname,
     });
     if (isDuplicated) {
       throw new BadRequestException('이미 존재하는 닉네임입니다.');
     }
-
-    return this.userRepository.update({ id: userId }, { nickname: newName });
   }
 }

--- a/BE/src/auth/user.service.ts
+++ b/BE/src/auth/user.service.ts
@@ -25,6 +25,12 @@ export class UserService {
       throw new BadRequestException('사용 불가능한 문자가 포함되어 있습니다.');
     }
 
+    const regex = /^[가-힣a-zA-Z0-9]+$/;
+
+    if (!regex.test(newName)) {
+      throw new BadRequestException('한글, 영문, 숫자만 사용 가능합니다.');
+    }
+
     const isDuplicated = await this.userRepository.existsBy({
       nickname: newName,
     });


### PR DESCRIPTION
### ✅ 주요 작업
- 한글(가-힣), 알파벳(a-zA-Z), 숫자(0-9)만 허용 가능한 정규식을 추가
- 닉네임 유효성 검사 로직을 함수로 분리

### 💭 고민과 해결과정
- 