### PR TITLE
[BE] 27.06 각 세션 별 중복되는 구독 관리

### DIFF
--- a/BE/.eslintrc.js
+++ b/BE/.eslintrc.js
@@ -35,5 +35,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/naming-convention': 'off',
+    'no-restricted-syntax': 'off',
+    'no-await-in-loop': 'off'
   },
 };

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -148,8 +148,10 @@ export class AssetService {
     const userStocks: UserStock[] =
       await this.userStockRepository.findAllDistinctCode(userId);
 
-    userStocks.map((userStock) =>
-      this.stockPriceSocketService.subscribeByCode(userStock.stock_code),
+    await Promise.all(
+      userStocks.map((userStock) =>
+        this.stockPriceSocketService.subscribeByCode(userStock.stock_code),
+      ),
     );
   }
 

--- a/BE/src/asset/asset.service.ts
+++ b/BE/src/asset/asset.service.ts
@@ -157,7 +157,7 @@ export class AssetService {
     const userStocks: UserStock[] =
       await this.userStockRepository.findAllDistinctCode(userId);
 
-    this.stockPriceSocketService.unsubscribeByCode(
+    await this.stockPriceSocketService.unsubscribeByCode(
       userStocks.map((userStock) => userStock.stock_code),
     );
   }

--- a/BE/src/common/redis/redis.domain-service.ts
+++ b/BE/src/common/redis/redis.domain-service.ts
@@ -12,11 +12,11 @@ export class RedisDomainService {
     return this.redis.exists(key);
   }
 
-  async get(key: string): Promise<string | null> {
+  async get(key: string): Promise<string | number | null> {
     return this.redis.get(key);
   }
 
-  async set(key: string, value: string, expires?: number): Promise<'OK'> {
+  async set(key: string, value: number, expires?: number): Promise<'OK'> {
     if (expires) {
       return this.redis.set(key, value, 'EX', expires);
     }
@@ -61,5 +61,31 @@ export class RedisDomainService {
 
   async expire(key: string, seconds: number): Promise<number> {
     return this.redis.expire(key, seconds);
+  }
+
+  async publish(channel: string, message: string) {
+    return this.redis.publish(channel, message);
+  }
+
+  async subscribe(channel: string) {
+    await this.redis.subscribe(channel);
+  }
+
+  on(callback: (message: string) => void) {
+    this.redis.on('message', (message) => {
+      callback(message);
+    });
+  }
+
+  async unsubscribe(channel: string) {
+    return this.redis.unsubscribe(channel);
+  }
+
+  async increment(key: string) {
+    return this.redis.incr(key);
+  }
+
+  async decrement(key: string) {
+    return this.redis.decr(key);
   }
 }

--- a/BE/src/stock/order/stock-order.service.ts
+++ b/BE/src/stock/order/stock-order.service.ts
@@ -111,7 +111,7 @@ export class StockOrderService {
         status: StatusType.PENDING,
       }))
     )
-      this.stockPriceSocketService.unsubscribeByCode([order.stock_code]);
+      await this.stockPriceSocketService.unsubscribeByCode([order.stock_code]);
   }
 
   async getPendingListByUserId(userId: number) {
@@ -135,7 +135,7 @@ export class StockOrderService {
     const orders: Order[] =
       await this.stockOrderRepository.findAllCodeByStatus();
 
-    this.stockPriceSocketService.unsubscribeByCode(
+    await this.stockPriceSocketService.unsubscribeByCode(
       orders.map((order) => order.stock_code),
     );
 

--- a/BE/src/stock/order/stock-order.service.ts
+++ b/BE/src/stock/order/stock-order.service.ts
@@ -54,7 +54,9 @@ export class StockOrderService {
     });
 
     await this.stockOrderRepository.save(order);
-    this.stockPriceSocketService.subscribeByCode(stockOrderRequest.stock_code);
+    await this.stockPriceSocketService.subscribeByCode(
+      stockOrderRequest.stock_code,
+    );
   }
 
   async sell(userId: number, stockOrderRequest: StockOrderRequestDto) {
@@ -89,7 +91,9 @@ export class StockOrderService {
     });
 
     await this.stockOrderRepository.save(order);
-    this.stockPriceSocketService.subscribeByCode(stockOrderRequest.stock_code);
+    await this.stockPriceSocketService.subscribeByCode(
+      stockOrderRequest.stock_code,
+    );
   }
 
   async cancel(userId: number, orderId: number) {

--- a/BE/src/stock/trade/history/stock-trade-history.controller.ts
+++ b/BE/src/stock/trade/history/stock-trade-history.controller.ts
@@ -74,8 +74,8 @@ export class StockTradeHistoryController {
     status: 200,
     description: '구독 취소 성공',
   })
-  unsubscribeCode(@Query('stockCode') stockCode: string | string[]) {
+  async unsubscribeCode(@Query('stockCode') stockCode: string | string[]) {
     const stockCodeArray = Array.isArray(stockCode) ? stockCode : [stockCode];
-    this.stockPriceSocketService.unsubscribeByCode(stockCodeArray);
+    await this.stockPriceSocketService.unsubscribeByCode(stockCodeArray);
   }
 }

--- a/BE/src/stock/trade/history/stock-trade-history.service.spec.ts
+++ b/BE/src/stock/trade/history/stock-trade-history.service.spec.ts
@@ -37,9 +37,7 @@ describe('stock trade history test', () => {
     jest
       .spyOn(koreaInvestmentDomainService, 'requestApi')
       .mockResolvedValueOnce(STOCK_TRADE_HISTORY_TODAY_MOCK);
-    jest
-      .spyOn(stockPriceSocketService, 'subscribeByCode')
-      .mockImplementation(() => {});
+    jest.spyOn(stockPriceSocketService, 'subscribeByCode').mockResolvedValue();
 
     const response =
       await stockTradeHistoryService.getTodayStockTradeHistory('005930');

--- a/BE/src/stock/trade/history/stock-trade-history.service.ts
+++ b/BE/src/stock/trade/history/stock-trade-history.service.ts
@@ -35,7 +35,7 @@ export class StockTradeHistoryService {
         queryParams,
       );
 
-    this.stockPriceSocketService.subscribeByCode(stockCode);
+    await this.stockPriceSocketService.subscribeByCode(stockCode);
     return this.formatTodayStockTradeHistoryData(response.output);
   }
 

--- a/BE/src/stockSocket/stock-price-socket.service.ts
+++ b/BE/src/stockSocket/stock-price-socket.service.ts
@@ -71,6 +71,7 @@ export class StockPriceSocketService extends BaseStockSocketDomainService {
     // 아무 서버도 한투와 구독 중이지 않을때
     if (!(await this.redisDomainService.exists(trKey))) {
       this.baseSocketDomainService.registerCode(this.TR_ID, trKey);
+      await this.redisDomainService.subscribe(`stock/${trKey}`);
       this.register.push(trKey);
       await this.redisDomainService.set(trKey, 1);
       this.connection[trKey] = 1;


### PR DESCRIPTION
### ✅ 주요 작업
- redis 설치
- redis로 전체 연결 관리
- redis pub/sub 기능을 이용해 중복 연결이 되지 않도록 변경

### 💭 고민과 해결과정
![image](https://github.com/user-attachments/assets/22aa661f-08bf-442a-a872-35544b677254)
- 그림과 같이, 서버 1에서 **`005930`** 이라는 종목 코드에 대해 구독 중이라면, 서버 2, 서버 3에서는 해당 종목을 한국투자 Open API Websocket과 직접 연결하지 않고, 서버 1에서 publish 한 정보를 바탕으로 가지고 올 수 있게 구현했습니다.